### PR TITLE
fix #14833 checking if the constant exists

### DIFF
--- a/lib/Mime/Viewer/Pdf.php
+++ b/lib/Mime/Viewer/Pdf.php
@@ -133,7 +133,9 @@ class IMP_Mime_Viewer_Pdf extends Horde_Mime_Viewer_Pdf
             if ($img instanceof Horde_Image_Imagick) {
                 /* Get rid of PDF transparency. */
                 $img->imagick->setImageBackgroundColor('white');
-                $img->imagick->setImageAlphaChannel(imagick::ALPHACHANNEL_REMOVE);
+                if (defined("imagick::ALPHACHANNEL_REMOVE")) {
+                    $img->imagick->setImageAlphaChannel(imagick::ALPHACHANNEL_REMOVE);
+                }
                 return $GLOBALS['injector']->getInstance('Horde_Core_Factory_Image')->create(array(
                     'data' => $img->imagick->mergeImageLayers(imagick::LAYERMETHOD_FLATTEN)->getImageBlob()
                 ));


### PR DESCRIPTION
Notice: needed in 6.x

This is a trivial fix to avoid 
`PHP Fatal error:  Undefined class constant 'ALPHACHANNEL_REMOVE' in /usr/share/horde/imp/lib/Mime/Viewer/Pdf.php on line 142, ...`

My first idea was to keep old code, after checking that `flattenImages` method exists (as it still exists in imagick 3.4.3 with IM 6, which is still the preferred version) but this method is deprecated (disapear in IM 7) and will probably raise a E_DEPRECATED message soon (see https://github.com/mkoppanen/imagick/pull/186)

I think the `mergeImageLayers` call should be enough in most case.