### PR TITLE
Bug: 14006 can't empty virtual trash in dynamic mode

### DIFF
--- a/js/dimpbase.js
+++ b/js/dimpbase.js
@@ -924,6 +924,7 @@ var DimpBase = {
             break;
 
         case 'ctx_mbox_empty':
+        case 'ctx_vtrash_empty':
             tmp = this.flist.getMbox(e);
             RedBox.loading();
             DimpCore.doAction('emptyMailboxPrepare', {
@@ -1369,6 +1370,7 @@ var DimpBase = {
         case 'ctx_container':
         case 'ctx_noactions':
         case 'ctx_remoteauth':
+        case 'ctx_vtrash':
         case 'ctx_vfolder':
             $(ctx_id).down('DIV.mboxName').update(this.flist.getMbox(e).fullMboxDisplay());
             break;
@@ -3655,7 +3657,11 @@ var DimpBase = {
 
         case 'vfolder':
             if (e.memo.virtual()) {
-                ftype = 'noactions';
+                if (e.memo.title() == 'impsearch\0vtrash') {
+                    ftype = 'vtrash';
+                } else {
+                    ftype = 'noactions';
+                }
             }
             break;
         }
@@ -4497,6 +4503,11 @@ var IMP_Flist_Mbox = Class.create({
     label: function()
     {
         return this.data.l;
+    },
+
+    title: function()
+    {
+        return this.data.t;
     },
 
     fs: function()

--- a/lib/Ajax/Application/Handler/Dynamic.php
+++ b/lib/Ajax/Application/Handler/Dynamic.php
@@ -198,8 +198,8 @@ extends Horde_Core_Ajax_Application_Handler
         if (!$mbox->access_empty) {
             $GLOBALS['notification']->push(sprintf(_("The mailbox \"%s\" may not be emptied."), $mbox->display), 'horde.error');
         } else {
-            $poll_info = $mbox->poll_info;
-            if (!($res->result = $poll_info->msgs)) {
+            $msg_count = $mbox->vtrash ? count ($mbox->list_ob) : $mbox->poll_info->msgs;
+            if (!($res->result = $msg_count)) {
                 $GLOBALS['notification']->push(sprintf(_("The mailbox \"%s\" is already empty."), $mbox->display), 'horde.message');
             }
         }

--- a/lib/Dynamic/Mailbox.php
+++ b/lib/Dynamic/Mailbox.php
@@ -275,6 +275,11 @@ class IMP_Dynamic_Mailbox extends IMP_Dynamic_Base
                 '_sep1' => null,
                 'edit' => _("Edit Virtual Folders")
             ),
+            'ctx_vtrash' => array(
+                '_mbox' => '',
+                '_sep1' => null,
+                'empty' => _("Empty"),
+            ),
             'ctx_vfolder' => array(
                 '_mbox' => '',
                 '_sep1' => null,


### PR DESCRIPTION
Add support for emptying virtual trash. It appears it was there at one
time, but lost long ago, possibly in e4e17b65e9677ccc60b75e0ae5763e2b48dc4e4d