### PR TITLE
Address ZDI-20-1051 / ZDI-CAN-10436: Prevent deserializing a class.

### DIFF
--- a/lib/Prefs/Sort.php
+++ b/lib/Prefs/Sort.php
@@ -39,9 +39,13 @@ class IMP_Prefs_Sort implements ArrayAccess, IteratorAggregate
     {
         global $prefs;
 
-        $sortpref = @unserialize($prefs->getValue(self::SORTPREF));
-        if (is_array($sortpref)) {
-            $this->_sortpref = $sortpref;
+        $serializedPref = $prefs->getValue(self::SORTPREF);
+        // Only unserialize non-empty strings. Disallow yielding any classes.
+        if (!empty($serializedPref && is_string($serializedPref))) {
+            $sortpref = @unserialize($serializedPref, ['allowed_classes' => false]);
+            if (is_array($sortpref)) {
+                $this->_sortpref = $sortpref;
+            }
         }
     }
 


### PR DESCRIPTION

Deal with https://www.zerodayinitiative.com/advisories/ZDI-20-1051/

Also guard against some other possibly unwanted deserialisations. It is debatable if this constitutes an actual attack vector before the change. However, the change rules out any such possibility.
See discussion on the ML https://lists.horde.org/archives/horde/Week-of-Mon-20221010/059302.html

@mrubinsk I have given this some limited functional testing but it might make sense to have a closer look.