### PR TITLE
wrapped param into floatval for round()

### DIFF
--- a/lib/Ajax/Queue.php
+++ b/lib/Ajax/Queue.php
@@ -290,7 +290,7 @@ class IMP_Ajax_Queue
             ($quotadata = $injector->getInstance('IMP_Quota_Ui')->quota($this->_quota[0], $this->_quota[1]))) {
             $ajax->addTask('quota', array(
                 'm' => $quotadata['message'],
-                'p' => round($quotadata['percent']),
+                'p' => round(floatval($quotadata['percent'])),
                 'l' => $quotadata['percent'] >= 90
                     ? 'alert'
                     : ($quotadata['percent'] >= 75 ? 'warn' : '')


### PR DESCRIPTION
Wrapped $quotadata['percent'] of type string with floatval to ensure round() gets a float as param