### PR TITLE
parentheses in the wrong spot

### DIFF
--- a/lib/Prefs/Sort.php
+++ b/lib/Prefs/Sort.php
@@ -41,7 +41,7 @@ class IMP_Prefs_Sort implements ArrayAccess, IteratorAggregate
 
         $serializedPref = $prefs->getValue(self::SORTPREF);
         // Only unserialize non-empty strings. Disallow yielding any classes.
-        if (!empty($serializedPref && is_string($serializedPref))) {
+        if (!empty($serializedPref) && is_string($serializedPref)) {
             $sortpref = @unserialize($serializedPref, ['allowed_classes' => false]);
             if (is_array($sortpref)) {
                 $this->_sortpref = $sortpref;


### PR DESCRIPTION
error message:
```
PHP Parse error:  syntax error, unexpected '&&' (T_BOOLEAN_AND), expecting ')' in /usr/share/horde/imp/lib/Prefs/Sort.php on line 44
```