### PR TITLE
Changes to support phpunit 9.x from Debian

### DIFF
--- a/lib/Ajax/Imple/ItipRequest.php
+++ b/lib/Ajax/Imple/ItipRequest.php
@@ -89,6 +89,10 @@ class IMP_Ajax_Imple_ItipRequest extends Horde_Core_Ajax_Imple
             $pos = strpos($key, '[');
             $key = substr($key, $pos + 1, strlen($key) - $pos - 2);
 
+            if (empty($key)) {
+              $key = 0;
+            }
+
             switch ($action) {
             case 'delete':
                 // vEvent cancellation.

--- a/lib/Indices.php
+++ b/lib/Indices.php
@@ -257,6 +257,7 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->_indices[$offset]);
@@ -264,6 +265,7 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return isset($this->_indices[$offset])
@@ -273,6 +275,7 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         unset($this->_indices[$offset]);
@@ -281,6 +284,7 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->_indices[$offset]);
@@ -293,6 +297,7 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
      *
      * @return integer  The number of indices.
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         $count = 0;
@@ -317,7 +322,7 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
     }
 
     /* Iterator methods. */
-
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if (!$this->valid()) {
@@ -331,11 +336,13 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
         return $ret;
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->_indices);
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if ($this->valid()) {
@@ -343,11 +350,13 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->_indices);
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return !is_null(key($this->_indices));

--- a/lib/Mbox/Parse.php
+++ b/lib/Mbox/Parse.php
@@ -98,6 +98,7 @@ class IMP_Mbox_Parse implements ArrayAccess, Countable, Iterator
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->_parsed[$offset]);
@@ -105,6 +106,7 @@ class IMP_Mbox_Parse implements ArrayAccess, Countable, Iterator
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (isset($this->_parsed[$offset])) {
@@ -147,6 +149,7 @@ class IMP_Mbox_Parse implements ArrayAccess, Countable, Iterator
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         // NOOP
@@ -154,6 +157,7 @@ class IMP_Mbox_Parse implements ArrayAccess, Countable, Iterator
 
     /**
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         // NOOP
@@ -166,6 +170,7 @@ class IMP_Mbox_Parse implements ArrayAccess, Countable, Iterator
      *
      * @return integer  The number of messages.
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_parsed);
@@ -178,6 +183,7 @@ class IMP_Mbox_Parse implements ArrayAccess, Countable, Iterator
      *
      * @return string  String representation.
      */
+    #[\ReturnTypeWillChange]
     public function __toString()
     {
         rewind($this->_data);
@@ -185,7 +191,7 @@ class IMP_Mbox_Parse implements ArrayAccess, Countable, Iterator
     }
 
     /* Iterator methods. */
-
+    #[\ReturnTypeWillChange]
     public function current()
     {
         $key = $this->key();
@@ -195,11 +201,13 @@ class IMP_Mbox_Parse implements ArrayAccess, Countable, Iterator
             : $this[$key];
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->_parsed);
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if ($this->valid()) {
@@ -207,11 +215,13 @@ class IMP_Mbox_Parse implements ArrayAccess, Countable, Iterator
         }
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->_parsed);
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return !is_null($this->key());

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,13 @@
-<phpunit bootstrap="test/Imp/bootstrap.php" colors="true">
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="test/Imp/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+  </coverage>
   <testsuites>
-    <testsuite>
+    <testsuite name="Horde IMP Unit Test">
       <directory>test</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist>
-      <directory suffix=".php">lib</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/test/Imp/Unit/ComposeTest.php
+++ b/test/Imp/Unit/ComposeTest.php
@@ -23,7 +23,7 @@
  * @package    IMP
  * @subpackage UnitTests
  */
-class Imp_Unit_ComposeTest extends PHPUnit_Framework_TestCase
+class Imp_Unit_ComposeTest extends Horde_Test_Case
 {
     public function testBug10431()
     {

--- a/test/Imp/Unit/MboxParseTest.php
+++ b/test/Imp/Unit/MboxParseTest.php
@@ -23,7 +23,7 @@
  * @package    IMP
  * @subpackage UnitTests
  */
-class Imp_Unit_MboxParseTest extends PHPUnit_Framework_TestCase
+class Imp_Unit_MboxParseTest extends Horde_Test_Case
 {
     public function testMboxParse()
     {
@@ -41,8 +41,7 @@ class Imp_Unit_MboxParseTest extends PHPUnit_Framework_TestCase
                 $key
             );
 
-            $this->assertInternalType(
-                'array',
+            $this->assertIsArray(
                 $val
             );
 
@@ -64,8 +63,7 @@ class Imp_Unit_MboxParseTest extends PHPUnit_Framework_TestCase
 
         $val = $parse[0];
 
-        $this->assertInternalType(
-            'array',
+        $this->assertIsArray(
             $val
         );
 
@@ -75,11 +73,10 @@ class Imp_Unit_MboxParseTest extends PHPUnit_Framework_TestCase
         );
     }
 
-    /**
-     * @expectedException IMP_Exception
-     */
     public function testBadData()
     {
+        $this->expectException('IMP_Exception');
+
         new IMP_Mbox_Parse(__DIR__ . '/noexist');
     }
 

--- a/test/Imp/Unit/Mime/Viewer/HtmlTest.php
+++ b/test/Imp/Unit/Mime/Viewer/HtmlTest.php
@@ -23,13 +23,13 @@
  * @package    IMP
  * @subpackage UnitTests
  */
-class Imp_Unit_Mime_Viewer_HtmlTest extends PHPUnit_Framework_TestCase
+class Imp_Unit_Mime_Viewer_HtmlTest extends Horde_Test_Case
 {
-    public function setUp()
+    public function setUp(): void
     {
-        $GLOBALS['browser'] = $this->getMock('Horde_Browser');
+        $GLOBALS['browser'] = $this->getMockBuilder('Horde_Browser')->getMock();
 
-        $prefs = $this->getMock('Horde_Prefs', array(), array(), '', false);
+        $prefs = $this->getMockBuilder('Horde_Prefs')->disableOriginalConstructor()->getMock();
         $prefs->expects($this->any())
             ->method('getValue')
             ->will($this->returnValue(false));
@@ -52,7 +52,7 @@ class Imp_Unit_Mime_Viewer_HtmlTest extends PHPUnit_Framework_TestCase
         );
 
         $v = new IMP_Stub_Mime_Viewer_Html(new Horde_Mime_Part(), array(
-            'browser' => $this->getMock('Horde_Browser'),
+            'browser' => $this->getMockBuilder('Horde_Browser')->getMock(),
             'charset' => 'UTF-8'
         ));
 
@@ -79,7 +79,7 @@ class Imp_Unit_Mime_Viewer_HtmlTest extends PHPUnit_Framework_TestCase
         );
 
         $v = new IMP_Stub_Mime_Viewer_Html(new Horde_Mime_Part(), array(
-            'browser' => $this->getMock('Horde_Browser'),
+            'browser' => $this->getMockBuilder('Horde_Browser')->getMock(),
             'charset' => 'UTF-8'
         ));
 

--- a/test/Imp/Unit/Mime/Viewer/ItipTest.php
+++ b/test/Imp/Unit/Mime/Viewer/ItipTest.php
@@ -25,7 +25,7 @@
  * @subpackage UnitTests
  */
 class Imp_Unit_Mime_Viewer_ItipTest
-extends PHPUnit_Framework_TestCase
+extends Horde_Test_Case
 {
     private $_contents;
     private $_contentsCharset;
@@ -39,18 +39,18 @@ extends PHPUnit_Framework_TestCase
     private $_notifyStack = array();
     private $_oldtz;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->_oldtz = date_default_timezone_get();
         date_default_timezone_set('UTC');
 
-        $injector = $this->getMock('Horde_Injector', array(), array(), '', false);
+        $injector = $this->getMockBuilder('Horde_Injector')->disableOriginalConstructor()->getMock();
         $injector->expects($this->any())
             ->method('getInstance')
             ->will($this->returnCallback(array($this, '_injectorGetInstance')));
         $GLOBALS['injector'] = $injector;
 
-        $registry = $this->getMock('Horde_Registry', array(), array(), '', false);
+        $registry = $this->getMockBuilder('Horde_Registry')->setMethods(array('getCharset','remoteHost'))->disableOriginalConstructor()->getMock();
         $registry->expects($this->any())
             ->method('getCharset')
             ->will($this->returnValue('UTF-8'));
@@ -59,7 +59,7 @@ extends PHPUnit_Framework_TestCase
             ->will($this->returnValue((object)array('addr' => '1.2.3.4', 'host' => 'example.com', 'proxy' => false)));
         $GLOBALS['registry'] = $registry;
 
-        $notification = $this->getMock('Horde_Notification_Handler', array(), array(), '', false);
+        $notification = $this->getMockBuilder('Horde_Notification_Handler')->disableOriginalConstructor()->getMock();
         $notification->expects($this->any())
             ->method('push')
             ->will($this->returnCallback(array($this, '_notificationHandler')));
@@ -69,7 +69,7 @@ extends PHPUnit_Framework_TestCase
         $_SERVER['REMOTE_ADDR'] = 'localhost';
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         date_default_timezone_set($this->_oldtz);
     }
@@ -85,7 +85,7 @@ extends PHPUnit_Framework_TestCase
 
         case 'IMP_Contents':
             if (!isset($this->_contents)) {
-                $contents= $this->getMock('IMP_Contents', array(), array(), '', false);
+                $contents= $this->getMockBuilder('IMP_Contents')->disableOriginalConstructor()->getMock();
                 $contents->expects($this->any())
                     ->method('getMIMEPart')
                     ->will($this->returnCallback(array($this, '_getMimePart')));
@@ -95,7 +95,7 @@ extends PHPUnit_Framework_TestCase
 
         case 'IMP_Factory_Contents':
             if (!isset($this->_contentsFactory)) {
-                $cf = $this->getMock('IMP_Factory_Contents', array(), array(), '', false);
+                $cf = $this->getMockBuilder('IMP_Factory_Contents')->disableOriginalConstructor()->getMock();
                 $cf->expects($this->any())
                     ->method('create')
                     ->will($this->returnValue($this->_injectorGetInstance('IMP_Contents')));
@@ -105,7 +105,7 @@ extends PHPUnit_Framework_TestCase
 
         case 'IMP_Factory_Imap':
             if (!isset($this->_imapFactory)) {
-                $imap = $this->getMock('IMP_Factory_Imap', array(), array(), '', false);
+                $imap = $this->getMockBuilder('IMP_Factory_Imap')->disableOriginalConstructor()->getMock();
                 $imap->expects($this->any())
                     ->method('create')
                     ->will($this->returnValue(new IMP_Stub_Imap()));
@@ -115,7 +115,7 @@ extends PHPUnit_Framework_TestCase
 
         case 'IMP_Factory_Mailbox':
             if (!isset($this->_mailbox)) {
-                $mbox = $this->getMock('IMP_Factory_Mailbox', array(), array(), '', false);
+                $mbox = $this->getMockBuilder('IMP_Factory_Mailbox')->disableOriginalConstructor()->getMock();
                 $mbox->expects($this->any())
                     ->method('create')
                     ->will($this->returnValue(new IMP_Mailbox('foo')));
@@ -125,7 +125,7 @@ extends PHPUnit_Framework_TestCase
 
         case 'IMP_Identity':
             if (!isset($this->_identity)) {
-                $identity = $this->getMock('Horde_Core_Prefs_Identity', array(), array(), '', false);
+                $identity = $this->getMockBuilder('Horde_Core_Prefs_Identity')->disableOriginalConstructor()->getMock();
                 $identity->expects($this->any())
                     ->method('setDefault')
                     ->will($this->returnCallback(array($this, '_identitySetDefault')));
@@ -232,7 +232,7 @@ extends PHPUnit_Framework_TestCase
     public function testAcceptingAnInvitationResultsInReplySent()
     {
         $this->_doImple('accept', $this->_getInvitation()->exportvCalendar());
-        $this->assertContains('Reply Sent.', reset($this->_notifyStack));
+        $this->assertStringContainsString('Reply Sent.', join(" ", reset($this->_notifyStack)));
     }
 
     /**
@@ -290,6 +290,8 @@ extends PHPUnit_Framework_TestCase
      */
     public function testResultMessageThrowsExceptionIfUidIsMissing()
     {
+        $this->expectNotToPerformAssertions();
+
         try {
             $this->_doImple('accept', "BEGIN:VEVENT\nORGANIZER:somebody@example.com\nDTSTAMP:20100816T143648Z\nDTSTART:20100816T143648Z\nEND:VEVENT");
             $this->fail('Expecting Exception.');
@@ -491,13 +493,13 @@ extends PHPUnit_Framework_TestCase
     public function testResultMimeMessageHeadersContainsReceivedHeader()
     {
         $this->_doImple('accept', $this->_getInvitation()->exportvCalendar());
-        $this->assertContains('(Horde Framework) with HTTP', $this->_getMailHeaders()->getValue('Received'));
+        $this->assertStringContainsString('(Horde Framework) with HTTP', $this->_getMailHeaders()->getValue('Received'));
     }
 
     public function testResultMimeMessageHeadersContainsMessageId()
     {
         $this->_doImple('accept', $this->_getInvitation()->exportvCalendar());
-        $this->assertContains('.Horde.', $this->_getMailHeaders()->getValue('Message-ID'));
+        $this->assertStringContainsString('.Horde.', $this->_getMailHeaders()->getValue('Message-ID'));
     }
 
     public function testResultMimeMessageHeadersContainsDate()

--- a/test/Imp/Unit/QuotaTest.php
+++ b/test/Imp/Unit/QuotaTest.php
@@ -23,7 +23,7 @@
  * @package    IMP
  * @subpackage UnitTests
  */
-class Imp_Unit_QuotaTest extends PHPUnit_Framework_TestCase
+class Imp_Unit_QuotaTest extends Horde_Test_Case
 {
     public function testMaildir()
     {


### PR DESCRIPTION
- Debian changes to support phpunit 9.x: https://salsa.debian.org/horde-team/php-horde-imp/-/blob/debian-sid/debian/patches/1010_phpunit-8.x%2B9.x.patch
- Debian fix for: set the key number, if the key is empty https://salsa.debian.org/horde-team/php-horde-imp/-/blob/debian-sid/debian/patches/3010_php8.1_regression.patch Bug-Debian: https://bugs.debian.org/1003746
