### PR TITLE
Fix security issues with HTML mails

### DIFF
--- a/lib/Mime/Viewer/Html.php
+++ b/lib/Mime/Viewer/Html.php
@@ -362,6 +362,16 @@ class IMP_Mime_Viewer_Html extends Horde_Mime_Viewer_Html
             $node->setAttribute('style', $style . 'width:auto !important');
             break;
 
+        case 'source':
+            if ($this->_imgBlock() &&
+                $node->hasAttribute('srcset'))
+            {
+                $node->setAttribute(self::SRCSETBLOCK, $node->getAttribute('srcset'));
+                $node->setAttribute('srcset', '');
+                $this->_imptmp['imgblock'] = true;
+                break;
+            }
+
         case 'img':
         case 'input':
             if ($node->hasAttribute('src')) {

--- a/lib/Mime/Viewer/Html.php
+++ b/lib/Mime/Viewer/Html.php
@@ -454,7 +454,7 @@ class IMP_Mime_Viewer_Html extends Horde_Mime_Viewer_Html
                 break;
             }
             if ($node->parentNode) {
-                node->parentNode->removeChild($node);
+                $node->parentNode->removeChild($node);
             }
             break;
 

--- a/lib/Mime/Viewer/Html.php
+++ b/lib/Mime/Viewer/Html.php
@@ -443,6 +443,9 @@ class IMP_Mime_Viewer_Html extends Horde_Mime_Viewer_Html
                 $node->parentNode->removeChild($node);
                 break;
             }
+            if ($node->parentNode) {
+                node->parentNode->removeChild($node);
+            }
             break;
 
         case 'table':


### PR DESCRIPTION
There was a recent report on the Horde mailing list about an exploit currently being used to inject malicious Javascript into the browser when a user just views a specially crafted e-mail in Horde/Imp. This vulnerability is known as CVE-2025-30349 by now (the CVE-ID was not known when the patch was developed).
The first commit fixes this issue, the second one a similar issue where a fix has been sitting in the traditional Horde bugtracker for years now and has not been merged. The third commit is a fix for the first commit, where I made a copy-paste error, not copying over a dollar sign.
