### PR TITLE
Refactor download URL extraction logic

### DIFF
--- a/js/smartmobile.js
+++ b/js/smartmobile.js
@@ -974,11 +974,23 @@ var ImpMobile = {
         var list = $('#imp-message-atclist').empty();
 
         $.each(ImpMobile.atc, function(k, v) {
+            var downloadUrl = v.download_url;
+            if (typeof downloadUrl !== 'string' || !downloadUrl.length || downloadUrl === '[object Object]') {
+                // Some backends serialize URL objects in AJAX payloads.
+                // Fallback: extract href from the rendered download link HTML.
+                downloadUrl = $('<div></div>').html(v.download || '').find('a').attr('href') || '';
+            }
+            if (!downloadUrl.length || downloadUrl === '[object Object]') {
+                return;
+            }
             list.append(
                 $('<li class="imp-message-atc"></li>').append(
+                    // Attachments must bypass jQuery Mobile AJAX navigation so
+                    // binary responses (PDF, etc.) are handled as direct HTTP.
                     $('<a></a>').attr({
-                        href: v.download_url,
-                        rel: 'external'
+                        href: downloadUrl,
+                        rel: 'external',
+                        'data-ajax': 'false'
                     }).append(
                         $(v.icon).addClass('ui-li-icon')
                     ).append(


### PR DESCRIPTION
## Summary
Fix smartmobile attachment links to open/download reliably on mobile by avoiding AJAX navigation and handling non-string `download_url` payloads.
## Context / Problem
In smartmobile mode, opening attachments (for example PDFs) could fail with blank/error pages.  
Root cause: attachment links were sometimes built from a non-string `download_url` value (serialized object), producing invalid URLs such as `[object Object]`. Also, attachment requests should bypass jQuery Mobile AJAX navigation for binary responses.
## Changes
### `vendor/horde/imp/js/smartmobile.js`
In `showAttachments()`:
- Force direct navigation for attachment links:
  - `rel: 'external'`
  - `data-ajax: 'false'`
- Add robust URL normalization:
  - Use `v.download_url` when it is a valid string.
  - If not, extract `href` from existing `v.download` HTML as fallback.
  - Skip rendering link when no valid URL can be resolved.
- Add a short inline comment documenting why attachments must bypass AJAX navigation.
## Why this approach
- Binary payloads (PDF/images/etc.) should be handled via normal HTTP navigation/download, not page-fragment AJAX routing.
- Fallback extraction from `v.download` keeps compatibility with payload variants where URL objects are serialized unexpectedly.
- Keeps fix localized to smartmobile attachment rendering without changing backend behavior.
## Behavioral Impact
- Smartmobile attachment links now resolve to valid URLs even when `download_url` is not a string.
- PDF and other attachment downloads/views open correctly on mobile.
- Prevents malformed URLs like `/imp/[object Object]`.
## Test Plan
- [ ] Open an email with PDF attachment in smartmobile mode and verify it opens/downloads.
- [ ] Repeat with image and generic binary attachments.
- [ ] Confirm attachment links no longer contain `[object Object]` in Network tab.
- [ ] Confirm dynamic mode behavior remains unchanged.