### PR TITLE
feat/base64 key

### DIFF
--- a/.horde.yml
+++ b/.horde.yml
@@ -105,7 +105,7 @@ autoload:
   classmap:
     - lib/
   psr-4:
-    Horde\Imp\: /src
+    Horde\Imp\: src/
 keywords:
   - webmail
   - imap

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,7 @@
             "lib/"
         ],
         "psr-4": {
-            "Horde\\Imp\\": "/src"
+            "Horde\\Imp\\": "src/"
         }
     },
     "autoload-dev": {

--- a/lib/Pgp.php
+++ b/lib/Pgp.php
@@ -11,6 +11,7 @@
  * @license   http://www.horde.org/licenses/gpl GPL
  * @package   IMP
  */
+use Horde\Imp\Crypt\KeyStorage;
 use function PHP81_BC\strftime;
 
 /**
@@ -42,6 +43,11 @@ class IMP_Pgp
     protected $_pgp;
 
     /**
+     * @var KeyStorage|null
+     */
+    private ?KeyStorage $_keyStorage = null;
+
+    /**
      * Return whether PGP support is current enabled in IMP.
      *
      * @return boolean  True if PGP support is enabled.
@@ -61,6 +67,14 @@ class IMP_Pgp
     public function __construct(Horde_Crypt_Pgp $pgp)
     {
         $this->_pgp = $pgp;
+    }
+
+    private function keyStorage(): KeyStorage
+    {
+        if ($this->_keyStorage === null) {
+            $this->_keyStorage = new KeyStorage();
+        }
+        return $this->_keyStorage;
     }
 
     /**
@@ -130,7 +144,10 @@ class IMP_Pgp
      */
     public function addPersonalPublicKey($public_key)
     {
-        $GLOBALS['prefs']->setValue('pgp_public_key', trim($public_key));
+        $GLOBALS['prefs']->setValue(
+            'pgp_public_key',
+            $this->keyStorage()->encode(trim($public_key))
+        );
     }
 
     /**
@@ -141,7 +158,10 @@ class IMP_Pgp
      */
     public function addPersonalPrivateKey($private_key)
     {
-        $GLOBALS['prefs']->setValue('pgp_private_key', trim($private_key));
+        $GLOBALS['prefs']->setValue(
+            'pgp_private_key',
+            $this->keyStorage()->encode(trim($private_key))
+        );
     }
 
     /**
@@ -151,7 +171,11 @@ class IMP_Pgp
      */
     public function getPersonalPublicKey()
     {
-        return $GLOBALS['prefs']->getValue('pgp_public_key');
+        return $this->keyStorage()->decode(
+            $GLOBALS['prefs']->getValue('pgp_public_key'),
+            'pgp_public_key',
+            $GLOBALS['prefs']
+        );
     }
 
     /**
@@ -161,7 +185,11 @@ class IMP_Pgp
      */
     public function getPersonalPrivateKey()
     {
-        return $GLOBALS['prefs']->getValue('pgp_private_key');
+        return $this->keyStorage()->decode(
+            $GLOBALS['prefs']->getValue('pgp_private_key'),
+            'pgp_private_key',
+            $GLOBALS['prefs']
+        );
     }
 
     /**

--- a/lib/Pgp.php
+++ b/lib/Pgp.php
@@ -171,11 +171,17 @@ class IMP_Pgp
      */
     public function getPersonalPublicKey()
     {
-        return $this->keyStorage()->decode(
-            $GLOBALS['prefs']->getValue('pgp_public_key'),
-            'pgp_public_key',
-            $GLOBALS['prefs']
-        );
+        $raw = $GLOBALS['prefs']->getValue('pgp_public_key');
+        $key = $this->keyStorage()->decode($raw, 'pgp_public_key', $GLOBALS['prefs']);
+
+        if ($raw !== '' && $key === '') {
+            $GLOBALS['notification']->push(
+                _("Your stored PGP public key appears corrupt and could not be loaded."),
+                'horde.warning'
+            );
+        }
+
+        return $key;
     }
 
     /**
@@ -185,11 +191,17 @@ class IMP_Pgp
      */
     public function getPersonalPrivateKey()
     {
-        return $this->keyStorage()->decode(
-            $GLOBALS['prefs']->getValue('pgp_private_key'),
-            'pgp_private_key',
-            $GLOBALS['prefs']
-        );
+        $raw = $GLOBALS['prefs']->getValue('pgp_private_key');
+        $key = $this->keyStorage()->decode($raw, 'pgp_private_key', $GLOBALS['prefs']);
+
+        if ($raw !== '' && $key === '') {
+            $GLOBALS['notification']->push(
+                _("Your stored PGP private key appears corrupt and could not be loaded."),
+                'horde.warning'
+            );
+        }
+
+        return $key;
     }
 
     /**

--- a/lib/Smime.php
+++ b/lib/Smime.php
@@ -12,7 +12,7 @@
  * @package   IMP
  */
 
-use Horde\Util\HordeString;
+use Horde\Imp\Crypt\KeyStorage;
 
 /**
  * Contains code related to handling S/MIME messages within IMP.
@@ -47,6 +47,11 @@ class IMP_Smime
     protected $_smime;
 
     /**
+     * @var KeyStorage|null
+     */
+    private ?KeyStorage $_keyStorage = null;
+
+    /**
      * Return whether PGP support is current enabled in IMP.
      *
      * @return boolean  True if PGP support is enabled.
@@ -68,6 +73,14 @@ class IMP_Smime
     public function __construct(Horde_Crypt_Smime $smime)
     {
         $this->_smime = $smime;
+    }
+
+    private function keyStorage(): KeyStorage
+    {
+        if ($this->_keyStorage === null) {
+            $this->_keyStorage = new KeyStorage();
+        }
+        return $this->_keyStorage;
     }
 
     /**
@@ -109,11 +122,7 @@ class IMP_Smime
     {
         $prefName = $signkey ? 'smime_public_sign_key' : 'smime_public_key';
         $val = is_array($key) ? implode('', $key) : $key;
-        try {
-            $val = HordeString::convertToUtf8($val);
-        } catch (Exception $ex) {
-        }
-        $GLOBALS['prefs']->setValue($prefName, $val);
+        $GLOBALS['prefs']->setValue($prefName, $this->keyStorage()->encode($val));
     }
 
     /**
@@ -126,11 +135,7 @@ class IMP_Smime
     {
         $prefName = $signkey ? 'smime_private_sign_key' : 'smime_private_key';
         $val = is_array($key) ? implode('', $key) : $key;
-        try {
-            $val = HordeString::convertToUtf8($val);
-        } catch (Exception $ex) {
-        }
-        $GLOBALS['prefs']->setValue($prefName, $val);
+        $GLOBALS['prefs']->setValue($prefName, $this->keyStorage()->encode($val));
     }
 
     /**
@@ -143,11 +148,7 @@ class IMP_Smime
     {
         $prefName = $signkey ? 'smime_additional_sign_cert' : 'smime_additional_cert';
         $val = is_array($key) ? implode('', $key) : $key;
-        try {
-            $val = HordeString::convertToUtf8($val);
-        } catch (Exception $ex) {
-        }
-        $GLOBALS['prefs']->setValue($prefName, $val);
+        $GLOBALS['prefs']->setValue($prefName, $this->keyStorage()->encode($val));
     }
 
     /**
@@ -161,11 +162,18 @@ class IMP_Smime
     {
         global $prefs;
 
-        $key = $prefs->getValue(
-            $signkey ? 'smime_public_sign_key' : 'smime_public_key'
+        $prefName = $signkey ? 'smime_public_sign_key' : 'smime_public_key';
+        $key = $this->keyStorage()->decode(
+            $prefs->getValue($prefName),
+            $prefName,
+            $prefs
         );
         if (!$key && $signkey == self::KEY_SECONDARY_OR_PRIMARY) {
-            $key = $prefs->getValue('smime_public_key');
+            $key = $this->keyStorage()->decode(
+                $prefs->getValue('smime_public_key'),
+                'smime_public_key',
+                $prefs
+            );
         }
 
         return $key;
@@ -182,11 +190,18 @@ class IMP_Smime
     {
         global $prefs;
 
-        $key = $prefs->getValue(
-            $signkey ? 'smime_private_sign_key' : 'smime_private_key'
+        $prefName = $signkey ? 'smime_private_sign_key' : 'smime_private_key';
+        $key = $this->keyStorage()->decode(
+            $prefs->getValue($prefName),
+            $prefName,
+            $prefs
         );
         if (!$key && $signkey == self::KEY_SECONDARY_OR_PRIMARY) {
-            $key = $prefs->getValue('smime_private_key');
+            $key = $this->keyStorage()->decode(
+                $prefs->getValue('smime_private_key'),
+                'smime_private_key',
+                $prefs
+            );
         }
 
         return $key;
@@ -203,11 +218,18 @@ class IMP_Smime
     {
         global $prefs;
 
-        $key = $prefs->getValue(
-            $signkey ? 'smime_additional_sign_cert' : 'smime_additional_cert'
+        $prefName = $signkey ? 'smime_additional_sign_cert' : 'smime_additional_cert';
+        $key = $this->keyStorage()->decode(
+            $prefs->getValue($prefName),
+            $prefName,
+            $prefs
         );
         if (!$key && $signkey == self::KEY_SECONDARY_OR_PRIMARY) {
-            $key = $prefs->getValue('smime_additional_cert');
+            $key = $this->keyStorage()->decode(
+                $prefs->getValue('smime_additional_cert'),
+                'smime_additional_cert',
+                $prefs
+            );
         }
 
         return $key;

--- a/lib/Smime.php
+++ b/lib/Smime.php
@@ -160,20 +160,29 @@ class IMP_Smime
      */
     public function getPersonalPublicKey($signkey = self::KEY_PRIMARY)
     {
-        global $prefs;
+        global $notification, $prefs;
 
         $prefName = $signkey ? 'smime_public_sign_key' : 'smime_public_key';
-        $key = $this->keyStorage()->decode(
-            $prefs->getValue($prefName),
-            $prefName,
-            $prefs
-        );
-        if (!$key && $signkey == self::KEY_SECONDARY_OR_PRIMARY) {
-            $key = $this->keyStorage()->decode(
-                $prefs->getValue('smime_public_key'),
-                'smime_public_key',
-                $prefs
+        $raw = $prefs->getValue($prefName);
+        $key = $this->keyStorage()->decode($raw, $prefName, $prefs);
+
+        if ($raw !== '' && $key === '') {
+            $notification->push(
+                _("Your stored S/MIME public key appears corrupt and could not be loaded."),
+                'horde.warning'
             );
+        }
+
+        if (!$key && $signkey == self::KEY_SECONDARY_OR_PRIMARY) {
+            $raw = $prefs->getValue('smime_public_key');
+            $key = $this->keyStorage()->decode($raw, 'smime_public_key', $prefs);
+
+            if ($raw !== '' && $key === '') {
+                $notification->push(
+                    _("Your stored S/MIME public key appears corrupt and could not be loaded."),
+                    'horde.warning'
+                );
+            }
         }
 
         return $key;
@@ -188,20 +197,29 @@ class IMP_Smime
      */
     public function getPersonalPrivateKey($signkey = self::KEY_PRIMARY)
     {
-        global $prefs;
+        global $notification, $prefs;
 
         $prefName = $signkey ? 'smime_private_sign_key' : 'smime_private_key';
-        $key = $this->keyStorage()->decode(
-            $prefs->getValue($prefName),
-            $prefName,
-            $prefs
-        );
-        if (!$key && $signkey == self::KEY_SECONDARY_OR_PRIMARY) {
-            $key = $this->keyStorage()->decode(
-                $prefs->getValue('smime_private_key'),
-                'smime_private_key',
-                $prefs
+        $raw = $prefs->getValue($prefName);
+        $key = $this->keyStorage()->decode($raw, $prefName, $prefs);
+
+        if ($raw !== '' && $key === '') {
+            $notification->push(
+                _("Your stored S/MIME private key appears corrupt and could not be loaded."),
+                'horde.warning'
             );
+        }
+
+        if (!$key && $signkey == self::KEY_SECONDARY_OR_PRIMARY) {
+            $raw = $prefs->getValue('smime_private_key');
+            $key = $this->keyStorage()->decode($raw, 'smime_private_key', $prefs);
+
+            if ($raw !== '' && $key === '') {
+                $notification->push(
+                    _("Your stored S/MIME private key appears corrupt and could not be loaded."),
+                    'horde.warning'
+                );
+            }
         }
 
         return $key;
@@ -216,20 +234,29 @@ class IMP_Smime
      */
     public function getAdditionalCert($signkey = self::KEY_PRIMARY)
     {
-        global $prefs;
+        global $notification, $prefs;
 
         $prefName = $signkey ? 'smime_additional_sign_cert' : 'smime_additional_cert';
-        $key = $this->keyStorage()->decode(
-            $prefs->getValue($prefName),
-            $prefName,
-            $prefs
-        );
-        if (!$key && $signkey == self::KEY_SECONDARY_OR_PRIMARY) {
-            $key = $this->keyStorage()->decode(
-                $prefs->getValue('smime_additional_cert'),
-                'smime_additional_cert',
-                $prefs
+        $raw = $prefs->getValue($prefName);
+        $key = $this->keyStorage()->decode($raw, $prefName, $prefs);
+
+        if ($raw !== '' && $key === '') {
+            $notification->push(
+                _("Your stored S/MIME certificate appears corrupt and could not be loaded."),
+                'horde.warning'
             );
+        }
+
+        if (!$key && $signkey == self::KEY_SECONDARY_OR_PRIMARY) {
+            $raw = $prefs->getValue('smime_additional_cert');
+            $key = $this->keyStorage()->decode($raw, 'smime_additional_cert', $prefs);
+
+            if ($raw !== '' && $key === '') {
+                $notification->push(
+                    _("Your stored S/MIME certificate appears corrupt and could not be loaded."),
+                    'horde.warning'
+                );
+            }
         }
 
         return $key;

--- a/src/Crypt/CorruptKeyException.php
+++ b/src/Crypt/CorruptKeyException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (GPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/gpl.
+ *
+ * @category  Horde
+ * @copyright 2026 Horde LLC
+ * @license   http://www.horde.org/licenses/gpl GPL
+ * @package   IMP
+ */
+
+namespace Horde\Imp\Crypt;
+
+use RuntimeException;
+
+/**
+ * Thrown when a stored cryptographic key is detected as corrupt
+ * and cannot be recovered.
+ *
+ * @author    Ralf Lang <lang@b1-systems.de>
+ * @category  Horde
+ * @copyright 2026 Horde LLC
+ * @license   http://www.horde.org/licenses/gpl GPL
+ * @package   IMP
+ */
+class CorruptKeyException extends RuntimeException
+{
+}

--- a/src/Crypt/KeyStorage.php
+++ b/src/Crypt/KeyStorage.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (GPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/gpl.
+ *
+ * @category  Horde
+ * @copyright 2026 Horde LLC
+ * @license   http://www.horde.org/licenses/gpl GPL
+ * @package   IMP
+ */
+
+namespace Horde\Imp\Crypt;
+
+/**
+ * Handles encoding, decoding, validation, and lazy-migration of
+ * cryptographic key material stored in Horde preferences.
+ *
+ * Keys are stored base64-encoded to prevent charset corruption by
+ * the prefs SQL backend. On read, detects legacy raw PEM values and
+ * migrates them transparently.
+ *
+ * @author    Ralf Lang <lang@b1-systems.de>
+ * @category  Horde
+ * @copyright 2026 Horde LLC
+ * @license   http://www.horde.org/licenses/gpl GPL
+ * @package   IMP
+ */
+class KeyStorage
+{
+    /**
+     * PEM envelope markers recognized by this class.
+     */
+    private const PEM_TYPES = [
+        'CERTIFICATE',
+        'TRUSTED CERTIFICATE',
+        'X509 CERTIFICATE',
+        'RSA PRIVATE KEY',
+        'PRIVATE KEY',
+        'ENCRYPTED PRIVATE KEY',
+        'RSA PUBLIC KEY',
+        'PUBLIC KEY',
+        'PGP PUBLIC KEY BLOCK',
+        'PGP PRIVATE KEY BLOCK',
+        'PGP MESSAGE',
+        'PGP SIGNATURE',
+    ];
+
+    /**
+     * Encode key data for safe storage in prefs.
+     *
+     * @param string $keyData Raw PEM key/certificate data.
+     * @return string Base64-encoded value safe from charset mangling.
+     */
+    public function encode(string $keyData): string
+    {
+        if ($keyData === '') {
+            return '';
+        }
+
+        return base64_encode($keyData);
+    }
+
+    /**
+     * Decode key data read from prefs.
+     *
+     * Handles three formats:
+     * - Empty string (no key stored)
+     * - Base64-encoded PEM (new format, already migrated)
+     * - Raw PEM (legacy format, triggers lazy migration)
+     *
+     * @param string $rawValue Value from prefs->getValue().
+     * @param string $prefName Pref key name (for migration write-back).
+     * @param object|null $prefs Prefs instance supporting setValue() for write-back.
+     * @return string Decoded PEM data, or '' if empty/corrupt.
+     */
+    public function decode(string $rawValue, string $prefName = '', ?object $prefs = null): string
+    {
+        if ($rawValue === '') {
+            return '';
+        }
+
+        // Try base64 decode first (new format)
+        $decoded = base64_decode($rawValue, true);
+        if ($decoded !== false && $this->isValidPem($decoded)) {
+            return $decoded;
+        }
+
+        // Check if it's raw PEM (legacy format)
+        if ($this->isValidPem($rawValue)) {
+            $this->migrate($rawValue, $prefName, $prefs);
+            return $rawValue;
+        }
+
+        // Data is corrupt
+        return '';
+    }
+
+    /**
+     * Check whether a string is structurally valid PEM data.
+     *
+     * Validates one or more concatenated PEM blocks. Each block must
+     * have matching BEGIN/END markers with a recognized type.
+     *
+     * @param string $data Data to validate.
+     * @return bool True if the data contains at least one valid PEM block.
+     */
+    public function isValidPem(string $data): bool
+    {
+        if ($data === '') {
+            return false;
+        }
+
+        $types = implode('|', array_map('preg_quote', self::PEM_TYPES));
+        $pattern = '/-----BEGIN (' . $types . ')-----\s*.+?\s*-----END \1-----/s';
+
+        return (bool) preg_match($pattern, $data);
+    }
+
+    /**
+     * Detect whether a raw pref value is in the new base64-encoded format.
+     *
+     * @param string $rawValue Value from prefs.
+     * @return bool True if the value is base64-encoded PEM.
+     */
+    public function isBase64Encoded(string $rawValue): bool
+    {
+        if ($rawValue === '') {
+            return false;
+        }
+
+        $decoded = base64_decode($rawValue, true);
+        if ($decoded === false) {
+            return false;
+        }
+
+        return $this->isValidPem($decoded);
+    }
+
+    /**
+     * Check whether a stored value is corrupt.
+     *
+     * A value is corrupt if it is non-empty but is neither valid
+     * base64-encoded PEM nor raw PEM.
+     *
+     * @param string $rawValue Value from prefs.
+     * @return bool True if the value is corrupt.
+     */
+    public function isCorrupt(string $rawValue): bool
+    {
+        if ($rawValue === '') {
+            return false;
+        }
+
+        if ($this->isBase64Encoded($rawValue)) {
+            return false;
+        }
+
+        if ($this->isValidPem($rawValue)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Lazy-migrate a raw PEM value to base64 encoding in prefs.
+     *
+     * @param string $rawPem The raw PEM data.
+     * @param string $prefName The preference name.
+     * @param object|null $prefs Prefs instance supporting setValue().
+     */
+    private function migrate(string $rawPem, string $prefName, ?object $prefs): void
+    {
+        if ($prefName === '' || $prefs === null) {
+            return;
+        }
+
+        if (!method_exists($prefs, 'setValue')) {
+            return;
+        }
+
+        $prefs->setValue($prefName, $this->encode($rawPem));
+    }
+}

--- a/src/Crypt/KeyStorage.php
+++ b/src/Crypt/KeyStorage.php
@@ -40,10 +40,15 @@ class KeyStorage
         'TRUSTED CERTIFICATE',
         'X509 CERTIFICATE',
         'RSA PRIVATE KEY',
+        'DSA PRIVATE KEY',
+        'EC PRIVATE KEY',
         'PRIVATE KEY',
         'ENCRYPTED PRIVATE KEY',
+        'OPENSSH PRIVATE KEY',
         'RSA PUBLIC KEY',
         'PUBLIC KEY',
+        'EC PARAMETERS',
+        'DH PARAMETERS',
         'PGP PUBLIC KEY BLOCK',
         'PGP PRIVATE KEY BLOCK',
         'PGP MESSAGE',
@@ -76,9 +81,11 @@ class KeyStorage
      * @param string $rawValue Value from prefs->getValue().
      * @param string $prefName Pref key name (for migration write-back).
      * @param object|null $prefs Prefs instance supporting setValue() for write-back.
+     * @param bool $strict If true, throws CorruptKeyException instead of returning ''.
      * @return string Decoded PEM data, or '' if empty/corrupt.
+     * @throws CorruptKeyException When $strict is true and data is corrupt.
      */
-    public function decode(string $rawValue, string $prefName = '', ?object $prefs = null): string
+    public function decode(string $rawValue, string $prefName = '', ?object $prefs = null, bool $strict = false): string
     {
         if ($rawValue === '') {
             return '';
@@ -97,6 +104,12 @@ class KeyStorage
         }
 
         // Data is corrupt
+        if ($strict) {
+            throw new CorruptKeyException(
+                sprintf('Corrupt key data in preference "%s"', $prefName)
+            );
+        }
+
         return '';
     }
 

--- a/test/Crypt/KeyStorageTest.php
+++ b/test/Crypt/KeyStorageTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright 2026 Horde LLC (http://www.horde.org/)
+ *
+ * See the enclosed file LICENSE for license information (GPL). If you
+ * did not receive this file, see http://www.horde.org/licenses/gpl.
+ *
+ * @category  Horde
+ * @copyright 2026 Horde LLC
+ * @license   http://www.horde.org/licenses/gpl GPL
+ * @package   IMP
+ */
+
+namespace Horde\IMP\Test\Crypt;
+
+use Horde\Imp\Crypt\KeyStorage;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the KeyStorage encode/decode/validate/migrate logic.
+ *
+ * @author    Ralf Lang <lang@b1-systems.de>
+ * @category  Horde
+ * @copyright 2026 Horde LLC
+ * @license   http://www.horde.org/licenses/gpl GPL
+ * @package   IMP
+ */
+#[CoversClass(KeyStorage::class)]
+class KeyStorageTest extends TestCase
+{
+    private KeyStorage $storage;
+
+    private const SAMPLE_CERT = "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpHYsb5oMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnRl\nc3RDQTAeFw0yNDAxMDEwMDAwMDBaFw0yNTAxMDEwMDAwMDBaMBExDzANBgNVBAMM\nBnRlc3RDQTBcMA0GCSqGSIb3DQEBAQUAAktAMEgCQQC7o96lu5Fqo1bCdHFjKSmP\nvqMM9MnFN0k1Nfbb3LYKi7NoFXCcPwDXiAVA2B5cFhPfPMKGCHoGfMKAoqPfn9NA\ngMBAAEwDQYJKoZIhvcNAQELBQADQQBiKLRsY/KsLupjPDj16DsGNEDi4IZ2epOt\nOKI98Rkwpv0U6r9DiagkmA00qDHrwwIhNjei5rnr/L+4MH4VqpBs\n-----END CERTIFICATE-----";
+
+    private const SAMPLE_PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----\nMIIBogIBAAJBALuj3qW7kWqjVsJ0cWMpKY++owz0ycU3STU19tvctgqLs2gVcJw/\nANeIBUDYHlwWE988woYIegZ8woCio9+f00CAwEAAQJAV89FbLEnISm/X6DxP+iCm\nt4S3LP3V0q4SKBF6j0ggVz1dlMphXYECiEGOFCXIH06Ksb7RQbvLXe/IAPjbV0Gn\nQIhAN6tl3xn7pGKdK0f8bI5Y15u3A5EkVpH9g/r4eOGF1qDAiEA2TW+K9nnF3f4\nE7LgGBsLbT9URgO3e5H/qDIr9OJuAvcCIBaECqBOU/JiEq0rVdcSr9hj7UZtwFc\nFOj5mBTHllVdAiEAw7zyVALNz1K03y5m+l3MO2z4HkJP5eB3SAuqRGHCVf0CIHAG\nX9l66vcCyX8FXGS+gD6G3qiyWj3mJBPbJPmH3mPD\n-----END RSA PRIVATE KEY-----";
+
+    private const SAMPLE_PGP_PUBLIC = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQENBGV0AAoBCADJ7KF0m2ltP4U2VVwjBkXm/RUIbFPGSJmDNgV1THMXwvT1sDfC\nhM5OUQZ5gkvw9ORBpFxSmFqHeh08dOoLBE8zC8IJmVR3Fd/XhJBpG0FkVepKNe7o\nPcRR4wGZ/T5r0k0LAqFvKBw8xNZFNneFMc4AXqGJEVrxaVq0K8yCFb/Q+SJojrGP\nZA+NBcOF5qR0qOF1ZQMEJADBJMbFARgZfFdMMXmPmr0FGWyCYI+YIv2Ev7pEAQGP\njCHh2FdE/RB0gA==\n=ABCD\n-----END PGP PUBLIC KEY BLOCK-----";
+
+    private const SAMPLE_PGP_PRIVATE = "-----BEGIN PGP PRIVATE KEY BLOCK-----\n\nlQOYBGV0AAoBCADJ7KF0m2ltP4U2VVwjBkXm/RUIbFPGSJmDNgV1THMXwvT1sDfC\nhM5OUQZ5gkvw9ORBpFxSmFqHeh08dOoLBE8zC8IJmVR3Fd/XhJBpG0FkVepKNe7o\nZA+NBcOF5qR0qOF1ZQMEJADBJMbFARgZfFdMMXmPmr0FGWyCYI+YIv2Ev7pEAQGP\njCHh2FdE/RB0gA==\n=EFGH\n-----END PGP PRIVATE KEY BLOCK-----";
+
+    private const SAMPLE_MULTI_CERT = "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpHYsb5oMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnRl\nc3RDQTBcMA0GCSqGSIb3DQEBAQUAAktAMEgCQQC7o96lu5Fqo1bCdHFjKSmP\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpHYsb5oMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnRl\nc3RDQTBcMA0GCSqGSIb3DQEBAQUAAktAMEgCQQC7o96lu5Fqo1bCdHFjKSmP\n-----END CERTIFICATE-----";
+
+    protected function setUp(): void
+    {
+        $this->storage = new KeyStorage();
+    }
+
+    public function testEncodeReturnsBase64(): void
+    {
+        $encoded = $this->storage->encode(self::SAMPLE_CERT);
+
+        $this->assertNotEquals(self::SAMPLE_CERT, $encoded);
+        $this->assertNotFalse(base64_decode($encoded, true));
+        $this->assertEquals(self::SAMPLE_CERT, base64_decode($encoded, true));
+    }
+
+    public function testEncodeEmptyReturnsEmpty(): void
+    {
+        $this->assertSame('', $this->storage->encode(''));
+    }
+
+    public function testDecodeBase64Pem(): void
+    {
+        $encoded = base64_encode(self::SAMPLE_PRIVATE_KEY);
+
+        $result = $this->storage->decode($encoded);
+
+        $this->assertEquals(self::SAMPLE_PRIVATE_KEY, $result);
+    }
+
+    public function testDecodeEmptyReturnsEmpty(): void
+    {
+        $this->assertSame('', $this->storage->decode(''));
+    }
+
+    public function testDecodeRawPemMigrates(): void
+    {
+        $prefs = new class {
+            public string $lastPrefName = '';
+            public string $lastValue = '';
+
+            public function setValue(string $prefName, string $value): void
+            {
+                $this->lastPrefName = $prefName;
+                $this->lastValue = $value;
+            }
+        };
+
+        $result = $this->storage->decode(self::SAMPLE_PRIVATE_KEY, 'smime_private_key', $prefs);
+
+        $this->assertEquals(self::SAMPLE_PRIVATE_KEY, $result);
+        $this->assertSame('smime_private_key', $prefs->lastPrefName);
+        $this->assertSame(base64_encode(self::SAMPLE_PRIVATE_KEY), $prefs->lastValue);
+    }
+
+    public function testDecodeRawPemWithoutPrefsDoesNotMigrate(): void
+    {
+        $result = $this->storage->decode(self::SAMPLE_PRIVATE_KEY);
+
+        $this->assertEquals(self::SAMPLE_PRIVATE_KEY, $result);
+    }
+
+    public function testDecodeCorruptReturnsEmpty(): void
+    {
+        $corrupt = 'this is not a key at all, just garbage data ñ€£';
+
+        $this->assertSame('', $this->storage->decode($corrupt));
+    }
+
+    public function testIsValidPemCert(): void
+    {
+        $this->assertTrue($this->storage->isValidPem(self::SAMPLE_CERT));
+    }
+
+    public function testIsValidPemPrivateKey(): void
+    {
+        $this->assertTrue($this->storage->isValidPem(self::SAMPLE_PRIVATE_KEY));
+    }
+
+    public function testIsValidPemPgpPublic(): void
+    {
+        $this->assertTrue($this->storage->isValidPem(self::SAMPLE_PGP_PUBLIC));
+    }
+
+    public function testIsValidPemPgpPrivate(): void
+    {
+        $this->assertTrue($this->storage->isValidPem(self::SAMPLE_PGP_PRIVATE));
+    }
+
+    public function testIsValidPemMultiBlock(): void
+    {
+        $this->assertTrue($this->storage->isValidPem(self::SAMPLE_MULTI_CERT));
+    }
+
+    public function testIsValidPemRejectsGarbage(): void
+    {
+        $this->assertFalse($this->storage->isValidPem('not a pem'));
+        $this->assertFalse($this->storage->isValidPem(''));
+        $this->assertFalse($this->storage->isValidPem('-----BEGIN FAKE-----'));
+    }
+
+    public function testIsBase64EncodedDetectsEncodedPem(): void
+    {
+        $encoded = base64_encode(self::SAMPLE_CERT);
+
+        $this->assertTrue($this->storage->isBase64Encoded($encoded));
+    }
+
+    public function testIsBase64EncodedRejectsRawPem(): void
+    {
+        $this->assertFalse($this->storage->isBase64Encoded(self::SAMPLE_CERT));
+    }
+
+    public function testIsBase64EncodedRejectsEmpty(): void
+    {
+        $this->assertFalse($this->storage->isBase64Encoded(''));
+    }
+
+    public function testIsBase64EncodedRejectsBase64NonPem(): void
+    {
+        $encoded = base64_encode('just some regular text');
+
+        $this->assertFalse($this->storage->isBase64Encoded($encoded));
+    }
+
+    public function testIsCorruptDetectsCorruption(): void
+    {
+        $this->assertTrue($this->storage->isCorrupt('corrupted data ñ€£'));
+    }
+
+    public function testIsCorruptReturnsFalseForEmpty(): void
+    {
+        $this->assertFalse($this->storage->isCorrupt(''));
+    }
+
+    public function testIsCorruptReturnsFalseForValidBase64(): void
+    {
+        $this->assertFalse($this->storage->isCorrupt(base64_encode(self::SAMPLE_CERT)));
+    }
+
+    public function testIsCorruptReturnsFalseForRawPem(): void
+    {
+        $this->assertFalse($this->storage->isCorrupt(self::SAMPLE_CERT));
+    }
+
+    public function testRoundTripCert(): void
+    {
+        $encoded = $this->storage->encode(self::SAMPLE_CERT);
+        $decoded = $this->storage->decode($encoded);
+
+        $this->assertSame(self::SAMPLE_CERT, $decoded);
+    }
+
+    public function testRoundTripPrivateKey(): void
+    {
+        $encoded = $this->storage->encode(self::SAMPLE_PRIVATE_KEY);
+        $decoded = $this->storage->decode($encoded);
+
+        $this->assertSame(self::SAMPLE_PRIVATE_KEY, $decoded);
+    }
+
+    public function testRoundTripPgpKey(): void
+    {
+        $encoded = $this->storage->encode(self::SAMPLE_PGP_PUBLIC);
+        $decoded = $this->storage->decode($encoded);
+
+        $this->assertSame(self::SAMPLE_PGP_PUBLIC, $decoded);
+    }
+
+    public function testRoundTripMultiCert(): void
+    {
+        $encoded = $this->storage->encode(self::SAMPLE_MULTI_CERT);
+        $decoded = $this->storage->decode($encoded);
+
+        $this->assertSame(self::SAMPLE_MULTI_CERT, $decoded);
+    }
+}

--- a/test/Crypt/KeyStorageTest.php
+++ b/test/Crypt/KeyStorageTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace Horde\IMP\Test\Crypt;
 
+use Horde\Imp\Crypt\CorruptKeyException;
 use Horde\Imp\Crypt\KeyStorage;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -218,5 +219,76 @@ class KeyStorageTest extends TestCase
         $decoded = $this->storage->decode($encoded);
 
         $this->assertSame(self::SAMPLE_MULTI_CERT, $decoded);
+    }
+
+    public function testIsValidPemEcPrivateKey(): void
+    {
+        $ecKey = "-----BEGIN EC PRIVATE KEY-----\nMHQCAQEEIBkg4LVWM9nuwNSk3yByxZpYRTBnVpqR1fR3YJig0bOdoAcGBSuBBAAi\noWQDYgAE2a8kaFME9dggFaXhelIpix0+MljTFVRkratfHsSqHpSN\n-----END EC PRIVATE KEY-----";
+
+        $this->assertTrue($this->storage->isValidPem($ecKey));
+    }
+
+    public function testIsValidPemDsaPrivateKey(): void
+    {
+        $dsaKey = "-----BEGIN DSA PRIVATE KEY-----\nMIIBugIBAAKBgQDRhGF7X4A0ZVlEg2ly5Hn2HQYH/MqSS+4qMB0\n-----END DSA PRIVATE KEY-----";
+
+        $this->assertTrue($this->storage->isValidPem($dsaKey));
+    }
+
+    public function testIsValidPemOpensshPrivateKey(): void
+    {
+        $opensshKey = "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAAB\n-----END OPENSSH PRIVATE KEY-----";
+
+        $this->assertTrue($this->storage->isValidPem($opensshKey));
+    }
+
+    public function testIsValidPemEcParameters(): void
+    {
+        $ecParams = "-----BEGIN EC PARAMETERS-----\nBggqhkjOPQMBBw==\n-----END EC PARAMETERS-----";
+
+        $this->assertTrue($this->storage->isValidPem($ecParams));
+    }
+
+    public function testIsValidPemDhParameters(): void
+    {
+        $dhParams = "-----BEGIN DH PARAMETERS-----\nMIIBCAKCAQEA7+giV6afJJkD5Vqm7cHEP1M1\n-----END DH PARAMETERS-----";
+
+        $this->assertTrue($this->storage->isValidPem($dhParams));
+    }
+
+    public function testRoundTripEcKey(): void
+    {
+        $ecKey = "-----BEGIN EC PRIVATE KEY-----\nMHQCAQEEIBkg4LVWM9nuwNSk3yByxZpYRTBnVpqR1fR3YJig0bOdoAcGBSuBBAAi\noWQDYgAE2a8kaFME9dggFaXhelIpix0+MljTFVRkratfHsSqHpSN\n-----END EC PRIVATE KEY-----";
+
+        $encoded = $this->storage->encode($ecKey);
+        $decoded = $this->storage->decode($encoded);
+
+        $this->assertSame($ecKey, $decoded);
+    }
+
+    public function testDecodeStrictThrowsOnCorruptData(): void
+    {
+        $corrupt = 'this is not a key at all, just garbage data';
+
+        $this->expectException(CorruptKeyException::class);
+        $this->expectExceptionMessage('Corrupt key data in preference "pgp_public_key"');
+
+        $this->storage->decode($corrupt, 'pgp_public_key', null, true);
+    }
+
+    public function testDecodeStrictDoesNotThrowOnValidData(): void
+    {
+        $encoded = base64_encode(self::SAMPLE_CERT);
+
+        $result = $this->storage->decode($encoded, 'smime_public_key', null, true);
+
+        $this->assertSame(self::SAMPLE_CERT, $result);
+    }
+
+    public function testDecodeStrictDoesNotThrowOnEmpty(): void
+    {
+        $result = $this->storage->decode('', 'pgp_public_key', null, true);
+
+        $this->assertSame('', $result);
     }
 }


### PR DESCRIPTION
Store keys as base64 strings and upgrade pre-existing stored keys.
Check key integrity and warn about broken keys.

Adresses horde/imp#39

- **feat: base64-encode keys for storage**
- **fix: Wrong prefix for PSR-4**
