### PR TITLE
Implement try-catch for old server key retrieval

### DIFF
--- a/lib/Application.php
+++ b/lib/Application.php
@@ -153,7 +153,11 @@ class IMP_Application extends Horde_Registry_Application
 
         /* Grab the current server from the session to correctly populate
          * login form. */
-        $this->_oldserver = $injector->getInstance('IMP_Factory_Imap')->create()->server_key;
+        try {
+            $this->_oldserver = $injector->getInstance('IMP_Factory_Imap')->create()->server_key;
+        } catch (Exception $e) {
+            $this->_oldserver = null;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Make IMP `logout()` resilient when IMAP/identity cannot be created during session teardown, so Horde-wide logout does not fail or log injector errors.

## Problem

During Horde `Registry::clearAuth()`, each authenticated application's `logout()` method runs. IMP's `logout()` always called:

```php
$this->_oldserver = $injector->getInstance('IMP_Factory_Imap')->create()->server_key;
```

That value is only used later in `authLoginParams()` to pre-select the mail server on the login form when `server_list` is `shown`. Creating `IMP_Imap` can pull in `IMP_Identity` and other dependencies.

In some logout contexts (e.g. smartmobile using `/auth/logout`, middleware boot with `authentication => 'none'`, or session already partially destroyed), that chain can throw—for example:

```
Cannot create IMP_Identity
  Root cause: imp identity driver does not exist.
```

Those exceptions are not required for logout itself (compose cleanup and mailbox list expiry already ran). A failed `_oldserver` lookup should not block or pollute logs during teardown.

## Solution

Wrap the IMAP server key lookup in `try/catch`. On failure, set `_oldserver` to `null` and continue. `authLoginParams()` already falls back when `_oldserver` is null:

```php
$selected = is_null($this->_oldserver)
    ? $GLOBALS['injector']->getInstance('Horde_Variables')->get('imp_server_key', IMP_Auth::getAutoLoginServer())
    : $this->_oldserver;
```

Logout completes; the login form may simply omit the previous server pre-selection.

## Changes

**`lib/Application.php`**

- In `logout()`, wrap `IMP_Factory_Imap::create()->server_key` in `try/catch (Exception $e)`.
- On exception, assign `$this->_oldserver = null`.

## Test plan

- [ ] Log in to IMP (dynamic and smartmobile views).
- [ ] Log out via Horde logout (topbar / smartmobile header).
- [ ] Confirm logout completes and login page loads without errors.
- [ ] With `server_list` set to `shown` in IMP config, confirm login form still works (server list or auto-login as before).
- [ ] Check logs: no `Cannot create IMP_Identity` (or related) errors during logout.
- [ ] Optional: log out while IMP session/IMAP cache is in a bad state; confirm logout still succeeds.