### PR TITLE
feat(imap): Support XOAUTH2 password objects in IMAP client

### DIFF
--- a/lib/Imap.php
+++ b/lib/Imap.php
@@ -240,16 +240,36 @@ class IMP_Imap implements Serializable
             throw $error;
         }
 
-        $imap_config = [
-            'hostspec' => $config->hostspec,
-            'id' => $config->id,
-            'password' => new IMP_Imap_Password($password),
-            'port' => $config->port,
-            'secure' => (($secure = $config->secure) ? $secure : false),
-            'username' => $username,
-            // IMP specific config
-            'imp:backend' => $skey,
-        ];
+        // Check if password is already an XOAUTH2 token object
+        if ($password instanceof Horde_Imap_Client_Password_Xoauth2) {
+            // XOAUTH2 authentication - pass token directly
+            $imap_config = [
+                'hostspec' => $config->hostspec,
+                'id' => $config->id,
+                'xoauth2_token' => $password,
+                // IMP stores password objects in session under 'IMP_Imap_Password/' keys.
+                // A placeholder is required to avoid null reference errors in code paths
+                // that assume a password object is always present, even with XOAUTH2.
+                'password' => new IMP_Imap_Password('xoauth2'),
+                'port' => $config->port,
+                'secure' => (($secure = $config->secure) ? $secure : false),
+                'username' => $username,
+                // IMP specific config
+                'imp:backend' => $skey,
+            ];
+        } else {
+            // Normal password authentication
+            $imap_config = [
+                'hostspec' => $config->hostspec,
+                'id' => $config->id,
+                'password' => new IMP_Imap_Password($password),
+                'port' => $config->port,
+                'secure' => (($secure = $config->secure) ? $secure : false),
+                'username' => $username,
+                // IMP specific config
+                'imp:backend' => $skey,
+            ];
+        }
 
         /* Needed here to set config information in createImapObject(). */
         $this->_config = $config;


### PR DESCRIPTION
  #### Summary                                                                    
                                                                                  
  This PR allows  IMP_Imap::createBaseImapObject()  to accept a                   
   Horde_Imap_Client_Password_Xoauth2  object as the  $password                   
  parameter, forwarding it as  xoauth2_token  to the IMAP client. This            
  enables XOAUTH2 IMAP authentication via the existing                            
   imap_preauthenticate  hook — no new hook is introduced.                        
                                                                                  
  #### Context                                                                    
                                                                                  
  Cyrus IMAP deployments using OAuth2/OIDC single sign-on (SASL XOAUTH2)          
  have no user password. The  imap_preauthenticate  hook already exists           
  and is called before each IMAP connection; an OIDC hook implementation          
  sets  $credentials['password']  to a                                            
   Horde_Imap_Client_Password_Xoauth2  object containing the current              
  OAuth2 access token.                                                            
                                                                                  
  Without this PR,  createBaseImapObject()  wraps every password —                
  including XOAUTH2 objects — blindly in  IMP_Imap_Password , which               
  discards the XOAUTH2 semantics and causes authentication failure. This          
  PR is a prerequisite for a forthcoming OIDC authentication driver for           
  Horde; rejecting or modifying it would require a full implementation          
  of how XOAUTH2 credentials are injected into IMP.                               
                                                                                  
  This PR is self-contained: it adds one  instanceof  check and a                 
  conditional branch. The existing password path is completely unchanged.         
                                                                                  
  #### Changes                                                                    
                                                                                  
   lib/Imap.php  —  createBaseImapObject()  detects whether                       
   $password  is a  Horde_Imap_Client_Password_Xoauth2  instance:                 
                                                                                  
  • XOAUTH2 path: passes the object as  xoauth2_token  in the IMAP                
  config array, and sets a placeholder  IMP_Imap_Password('xoauth2')              
  to satisfy code paths that assume a password object is always                   
  present. The  xoauth2_token  key is recognised by                               
   Horde_Imap_Client_Socket  and triggers XOAUTH2 authentication.                 
  • Password path: unchanged — wraps the password in                              
   IMP_Imap_Password  as before.                                                  
                                                                                  
  The placeholder  IMP_Imap_Password('xoauth2')  is needed because                
  several IMP code paths (session serialization, reconnect logic)                 
  dereference the password object without checking its type. The string           
   'xoauth2'  is a safe sentinel that will not be mistaken for a real             
  credential.                                                                     
                                                                                  
  #### Tests                                                                      
                                                                                  
  No new unit tests in this PR. The  imap_preauthenticate  hook                   
  integration requires a live IMAP server. The change is a                
  minimal, isolated  instanceof  guard with no logic other than routing           
  to the appropriate config array shape.