### PR TITLE
Class IMP_Imap not found

### DIFF
--- a/src/IdentityDriverPrefs.php
+++ b/src/IdentityDriverPrefs.php
@@ -23,6 +23,7 @@ use Horde_Prefs_Exception;
 use IMP;
 use IMP_Compose;
 use IMP_Compose_Exception;
+use IMP_Imap;
 use IMP_Mailbox;
 use IMP_Mailbox_SessionCache;
 


### PR DESCRIPTION
When opening the compose window, a fatal error was thrown:

    Error: Class "Horde\Imp\IMP_Imap" not found
    in src/IdentityDriverPrefs.php:621

Add `use IMP_Imap;` to the existing `use` block at the top of
`src/IdentityDriverPrefs.php`, consistent with how other legacy
`IMP_*` classes are already imported in the same file.

