### PR TITLE
Fix/mobile attachment

### DIFF
--- a/js/smartmobile.js
+++ b/js/smartmobile.js
@@ -974,9 +974,14 @@ var ImpMobile = {
         var list = $('#imp-message-atclist').empty();
 
         $.each(ImpMobile.atc, function(k, v) {
-            var downloadUrl = String(v.download_url || '');
+            var downloadUrl = v.download_url;
+            if (typeof downloadUrl !== 'string') {
+                if (downloadUrl != null) {
+                    console.log('IMP smartmobile: attachment download_url must be a string', v);
+                }
+                return;
+            }
             if (!downloadUrl.length) {
-                console.log('IMP smartmobile: attachment missing download_url', v);
                 return;
             }
             list.append(

--- a/lib/Contents/Message.php
+++ b/lib/Contents/Message.php
@@ -218,7 +218,8 @@ class IMP_Contents_Message
                 $tmp = [];
                 foreach ($part_info as $val) {
                     if (isset($summary[$val])) {
-                        $tmp[$val] = ($summary[$val] instanceof Horde_Url)
+                        $tmp[$val] = ($summary[$val] instanceof Horde_Url
+                            || $summary[$val] instanceof \Horde\Url\Url)
                             ? strval($summary[$val]->setRaw(true))
                             : $summary[$val];
                     }


### PR DESCRIPTION
# Fix smartmobile attachment links (Horde\Url\Url)

Fixes [horde/imp#55](https://github.com/horde/imp/issues/55)

## Summary

- Stringify `\Horde\Url\Url` in attachment AJAX data (`IMP_Contents_Message::showMessage()`), not only `Horde_Url`.
- In `smartmobile.js`, require `download_url` to be a string so a bad payload cannot produce `/imp/[object Object]`.

## Problem

`Registry::downloadUrl()` returns `Horde\Url\Url`. Smartmobile only coerced `Horde_Url`, so `download_url` was JSON-encoded as `{}`. The client then built links as `/imp/[object Object]`.

## Test plan

- [ ] Mobile view: open a message with an attachment, expand attachments, tap download — file opens or saves (no routing error).
- [ ] Desktop IMP message view: attachment list unchanged.
