### PR TITLE
refactor(imp): retire 'hashtable' IMAP cache driver, fall through to 'cache'

### DIFF
--- a/lib/Contents/Message.php
+++ b/lib/Contents/Message.php
@@ -219,7 +219,7 @@ class IMP_Contents_Message
                 foreach ($part_info as $val) {
                     if (isset($summary[$val])) {
                         $tmp[$val] = ($summary[$val] instanceof Horde_Url
-                            || $summary[$val] instanceof \Horde\Url\Url)
+                            || $summary[$val] instanceof Horde\Url\Url)
                             ? strval($summary[$val]->setRaw(true))
                             : $summary[$val];
                     }

--- a/lib/Imap/Cache/Wrapper.php
+++ b/lib/Imap/Cache/Wrapper.php
@@ -70,15 +70,19 @@ class IMP_Imap_Cache_Wrapper implements Serializable
 
         switch ($this->_params['driver']) {
             case 'cache':
+            case 'hashtable':
+                /* The 'hashtable' driver is retired. The legacy
+                 * Horde_Imap_Client_Cache_Backend_Hashtable bypassed
+                 * Horde_Cache to write one entry per UID, optimized for
+                 * Memcache 1.0's poor multi-get performance. Modern Redis
+                 * (with MGET/pipelining) handles the sliced strategy of
+                 * Backend_Cache equally well, and going through Horde_Cache
+                 * gives one code path with consistent TTL/age handling. Old
+                 * configurations that still set driver='hashtable' fall
+                 * through here so users do not need to update their config
+                 * during the migration period. */
                 $ob = new Horde_Imap_Client_Cache_Backend_Cache(array_filter([
                     'cacheob' => $injector->getInstance('Horde_Cache'),
-                    'lifetime' => ($this->_params['lifetime'] ?? null),
-                ]));
-                break;
-
-            case 'hashtable':
-                $ob = new Horde_Imap_Client_Cache_Backend_Hashtable(array_filter([
-                    'hashtable' => $injector->getInstance('Horde_HashTable'),
                     'lifetime' => ($this->_params['lifetime'] ?? null),
                 ]));
                 break;


### PR DESCRIPTION
The 'hashtable' driver in `IMP_Imap_Cache_Wrapper` is retired. Existing configurations that set `cache.driver = 'hashtable'` for the IMAP cache fall through to the 'cache' branch, which uses `Horde_Cache` (which can itself be backed by the modern HashTable).

Rationale: see https://github.com/horde/Imap_Client/pull/46 — the per-UID `Backend_Hashtable` strategy was justified for Memcache 1.0 with poor multi-get; modern Redis handles the sliced strategy of `Backend_Cache` equally well. One code path with consistent TTL/age handling is preferable to two.

No config change required for existing deployments.

Refs https://github.com/horde/Core/issues/131