### PR TITLE
fix(imp): guard missing HTTP_HOST in getAutoLoginServer()

### DIFF
--- a/lib/Auth.php
+++ b/lib/Auth.php
@@ -177,9 +177,11 @@ class IMP_Auth
              * server for this web server. This decision is based on the
              * global 'SERVER_NAME' and 'HTTP_HOST' server variables and the
              * contents of the 'preferred' field in the backend's config. */
+            $serverName = $_SERVER['SERVER_NAME'] ?? null;
+            $httpHost = $_SERVER['HTTP_HOST'] ?? null;
             if (($preferred = $val->preferred)
-                && (in_array($_SERVER['SERVER_NAME'], $preferred)
-                 || in_array($_SERVER['HTTP_HOST'], $preferred))) {
+                && (($serverName !== null && in_array($serverName, $preferred))
+                 || ($httpHost !== null && in_array($httpHost, $preferred)))) {
                 return $key;
             }
         }


### PR DESCRIPTION
# Guard missing `HTTP_HOST` in `IMP_Auth::getAutoLoginServer()`

## Summary

- Read `$_SERVER['SERVER_NAME']` and `$_SERVER['HTTP_HOST']` safely before matching against a backend's `preferred` hostname list.
- Avoid PHP 8+ "Undefined array key" warnings when either variable is unset.
- Preserve existing autologin behavior for normal web requests where both values are present.

## Problem

`IMP_Auth::getAutoLoginServer()` selects the default IMAP server when a backend defines `preferred` hostnames. The check used `$_SERVER['SERVER_NAME']` and `$_SERVER['HTTP_HOST']` directly:

```php
if (($preferred = $val->preferred)
    && (in_array($_SERVER['SERVER_NAME'], $preferred)
     || in_array($_SERVER['HTTP_HOST'], $preferred))) {
```

If `SERVER_NAME` does not match the preferred list, PHP still evaluates `HTTP_HOST`. When that key is missing, PHP 8+ logs a warning such as:

```
PHP ERROR: Undefined array key "HTTP_HOST" [pid … on line 182 of "…/vendor/horde/imp/lib/Auth.php"]
```

This can occur outside a typical browser request, for example:

- CLI scripts and cron jobs that bootstrap IMP
- Internal requests without a `Host` header
- Environments where the web server sets `SERVER_NAME` but not `HTTP_HOST`

Installations with `preferred` configured in `backends.local.php` hit this code path on every autologin server lookup, so the warning can appear frequently in `horde.log` even though functionality otherwise continues.

## Solution

Extract both server variables with null coalescing and only pass defined values to `in_array()`:

```php
$serverName = $_SERVER['SERVER_NAME'] ?? null;
$httpHost = $_SERVER['HTTP_HOST'] ?? null;
if (($preferred = $val->preferred)
    && (($serverName !== null && in_array($serverName, $preferred))
     || ($httpHost !== null && in_array($httpHost, $preferred)))) {
```

This matches the defensive pattern already used elsewhere in Horde (for example `Horde\Core\Config\Vhost` and `horde/config/conf.php.dist`).

When neither variable is set, the method falls through to the first non-disabled server key, same as when neither hostname matches `preferred`.

## Related work

Similar unchecked `$_SERVER['HTTP_HOST']` access exists in other Horde apps (`ingo`, `passwd`). Those are out of scope for this PR but may warrant the same treatment if warnings appear there.

## Test plan

- [ ] Reproduce the original warning: bootstrap IMP with `preferred` set and `HTTP_HOST` unset; confirm no PHP warning is logged.
- [ ] With `preferred` matching `SERVER_NAME`, confirm the correct backend is selected as the autologin server.
- [ ] With `preferred` matching only `HTTP_HOST`, confirm the correct backend is still selected on a normal HTTP request.
- [ ] With neither hostname matching `preferred`, confirm the first enabled server is returned as before.
- [ ] Verify web login and transparent IMAP auth still work for an installation using `hordeauth`.
