### PR TITLE
fix(imp): invalidate search cache when mailboxes change

### DIFF
--- a/lib/Ajax/Application.php
+++ b/lib/Ajax/Application.php
@@ -283,11 +283,6 @@ class IMP_Ajax_Application extends Horde_Core_Ajax_Application
             return true;
         }
 
-        /* Only update search mailboxes on forced refreshes. */
-        if ($this->indices->mailbox->search) {
-            return !empty($this->_vars->forceUpdate);
-        }
-
         if (!$this->_vars->viewport->cacheid) {
             return false;
         }
@@ -414,6 +409,11 @@ class IMP_Ajax_Application extends Horde_Core_Ajax_Application
      */
     public function deleteMsgs(IMP_Indices $indices, $changed, $force = false)
     {
+        /* Search results may have been invalidated during deletion. */
+        if (!$changed) {
+            $changed = $this->changed(true);
+        }
+
         /* Check if we need to update thread information. */
         if (!$changed) {
             $changed = ($this->indices->mailbox->getSort()->sortby == Horde_Imap_Client::SORT_THREAD);

--- a/lib/Contents.php
+++ b/lib/Contents.php
@@ -1322,8 +1322,14 @@ class IMP_Contents
      */
     protected function _fetchData(Horde_Imap_Client_Fetch_Query $query)
     {
+        $mbox = $this->getMailbox();
+        if (!$mbox) {
+            $e = new IMP_Exception(_('Error displaying message: message does not exist on server.'));
+            $e->setLogLevel('NOTICE');
+            throw $e;
+        }
+
         try {
-            $mbox = $this->getMailbox();
             $imp_imap = $mbox->imp_imap;
             return $imp_imap->fetch($mbox, $query, [
                 'ids' => $imp_imap->getIdsOb($this->getUid()),

--- a/lib/Indices.php
+++ b/lib/Indices.php
@@ -291,6 +291,7 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
         }
         $imap_move = false;
         $return_value = true;
+        $affected_mailboxes = [];
 
         switch ($action) {
             case 'move':
@@ -326,6 +327,11 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
                     'ids' => $imp_imap->getIdsOb($ob->uids),
                     'move' => $imap_move,
                 ]);
+
+                if ($imap_move) {
+                    $affected_mailboxes[strval($ob->mbox)] = $ob->mbox;
+                    $affected_mailboxes[strval($targetMbox)] = $targetMbox;
+                }
             } catch (Exception $e) {
                 $error_msg = sprintf(
                     $message,
@@ -341,6 +347,12 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
 
                 $return_value = false;
             }
+        }
+
+        if ($return_value && $imap_move && !empty($affected_mailboxes)) {
+            $GLOBALS['injector']->getInstance('IMP_Search')->invalidateMailboxes(
+                array_values($affected_mailboxes)
+            );
         }
 
         return $return_value;
@@ -385,6 +397,7 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
             ? $injector->getInstance('IMP_Maillog')
             : null;
         $return_value = 0;
+        $affected_mailboxes = [];
 
         /* Check for Trash mailbox. */
         $no_expunge = $use_trash_mbox = $use_vtrash = false;
@@ -428,12 +441,9 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
                 continue;
             }
 
-            if ($return_value !== false) {
-                $return_value += count($ob->uids);
-            }
-
             $imp_imap = $ob->mbox->imp_imap;
             $ids_ob = $imp_imap->getIdsOb($ob->uids);
+            $processed = false;
 
             /* Trash is only valid for IMAP mailboxes. */
             if ($use_trash_mbox
@@ -453,6 +463,9 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
                             'ids' => $ids_ob,
                             'move' => true,
                         ]);
+                        $affected_mailboxes[strval($ob->mbox)] = $ob->mbox;
+                        $affected_mailboxes[strval($trash)] = $trash;
+                        $processed = true;
                     } catch (IMP_Imap_Exception $e) {
                         if ($e->getCode() == $e::OVERQUOTA) {
                             $notification->push(
@@ -510,9 +523,22 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
                             new IMP_Indices($ob->mbox, $ids_ob)
                         );
                     }
+
+                    $affected_mailboxes[strval($ob->mbox)] = $ob->mbox;
+                    $processed = true;
                 } catch (IMP_Imap_Exception $e) {
                 }
             }
+
+            if ($processed && ($return_value !== false)) {
+                $return_value += count($ob->uids);
+            }
+        }
+
+        if ($return_value !== false && !empty($affected_mailboxes)) {
+            $injector->getInstance('IMP_Search')->invalidateMailboxes(
+                array_values($affected_mailboxes)
+            );
         }
 
         return $return_value;

--- a/lib/Mailbox.php
+++ b/lib/Mailbox.php
@@ -1363,6 +1363,15 @@ class IMP_Mailbox
             }
         }
 
+        if (!empty($update_list)) {
+            $GLOBALS['injector']->getInstance('IMP_Search')->invalidateMailboxes(
+                array_filter(array_map(
+                    [IMP_Mailbox::class, 'get'],
+                    array_keys($update_list)
+                ))
+            );
+        }
+
         if ($msg_list) {
             return new IMP_Indices($update_list);
         }
@@ -1591,8 +1600,8 @@ class IMP_Mailbox
      * from the mailbox. Additionally, if CONDSTORE is available on the remote
      * IMAP server, this ID will change if flag information changes.
      *
-     * For search mailboxes, this value never changes (search mailboxes must
-     * be forcibly refreshed).
+     * For search mailboxes, this value changes when underlying mailbox
+     * contents change or when search display preferences change.
      *
      * @param boolean $date  If true, adds date information to ID.
      *
@@ -1601,15 +1610,11 @@ class IMP_Mailbox
      */
     protected function _getCacheID($date = false)
     {
-        global $prefs;
+        global $injector, $prefs;
 
         $date = $date
             ? 'D' . date('z')
             : '';
-
-        if ($this->search) {
-            return '1' . ($date ? '|' . $date : '');
-        }
 
         $sortpref = $this->getSort(true);
         $addl = [
@@ -1619,6 +1624,16 @@ class IMP_Mailbox
         ];
         if ($date) {
             $addl[] = $date;
+        }
+
+        if ($this->search) {
+            $cache_gen = 0;
+            $imp_search = $injector->getInstance('IMP_Search');
+            if ($imp_search->offsetExists($this->_mbox)) {
+                $cache_gen = $imp_search[$this->_mbox]->cacheGeneration();
+            }
+
+            return $cache_gen . '|' . implode('|', $addl);
         }
 
         try {

--- a/lib/Search.php
+++ b/lib/Search.php
@@ -446,6 +446,65 @@ class IMP_Search implements ArrayAccess, IteratorAggregate, Serializable
     }
 
     /**
+     * Invalidate cached search results for queries that include the given
+     * mailboxes.
+     *
+     * @param array $mboxes  List of IMP_Mailbox objects and/or mailbox names.
+     */
+    public function invalidateMailboxes(array $mboxes)
+    {
+        global $injector;
+
+        if (empty($mboxes)) {
+            return;
+        }
+
+        $mboxes = array_unique(array_filter(array_map(
+            'strval',
+            array_map([IMP_Mailbox::class, 'get'], $mboxes)
+        )));
+
+        $list_factory = $injector->getInstance('IMP_Factory_MailboxList');
+
+        foreach (['query', 'vfolders'] as $type) {
+            foreach ($this->_search[$type] as $query) {
+                if (!$this->_queryAffected($query, $mboxes)) {
+                    continue;
+                }
+
+                $query->invalidateCache();
+                $list_factory->create($query->mid)->rebuild(true);
+                $this->changed = true;
+            }
+        }
+    }
+
+    /**
+     * Does a search query include any of the given mailboxes?
+     *
+     * @param IMP_Search_Query $query   Search query object.
+     * @param array $mboxes             List of mailbox names.
+     *
+     * @return boolean
+     */
+    protected function _queryAffected(IMP_Search_Query $query, array $mboxes)
+    {
+        if ($query->all) {
+            return true;
+        }
+
+        $mboxes = array_flip($mboxes);
+
+        foreach ($query->mboxes as $mbox) {
+            if (isset($mboxes[strval($mbox)])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Strip the identifying label from a mailbox ID.
      *
      * @param string $id  The mailbox query ID.

--- a/lib/Search/Query.php
+++ b/lib/Search/Query.php
@@ -66,6 +66,13 @@ class IMP_Search_Query implements Serializable
     protected $_cache = [];
 
     /**
+     * Cache generation. Incremented when underlying mailbox contents change.
+     *
+     * @var integer
+     */
+    protected $_cacheGen = 0;
+
+    /**
      * Can this query be edited?
      *
      * @var boolean
@@ -327,6 +334,25 @@ class IMP_Search_Query implements Serializable
     }
 
     /**
+     * Return the cache generation for this query.
+     *
+     * @return integer
+     */
+    public function cacheGeneration()
+    {
+        return $this->_cacheGen;
+    }
+
+    /**
+     * Invalidate cached search results for this query.
+     */
+    public function invalidateCache()
+    {
+        ++$this->_cacheGen;
+        $this->_cache = [];
+    }
+
+    /**
      * Reduce the sorted return ID list by running search element callbacks..
      *
      * @param IMP_Mailbox $mbox  Mailbox.
@@ -366,6 +392,7 @@ class IMP_Search_Query implements Serializable
             'm' => $this->_mboxes,
             'v' => self::VERSION,
         ]);
+        $data['g'] = $this->_cacheGen;
 
         foreach ($this->_nosave as $val) {
             unset($data[$val]);
@@ -383,6 +410,7 @@ class IMP_Search_Query implements Serializable
             'm' => $this->_mboxes,
             'v' => self::VERSION,
         ]);
+        $data['g'] = $this->_cacheGen;
 
         foreach ($this->_nosave as $val) {
             unset($data[$val]);
@@ -420,6 +448,9 @@ class IMP_Search_Query implements Serializable
         if (isset($data['m'])) {
             $this->_mboxes = $data['m'];
         }
+        if (isset($data['g'])) {
+            $this->_cacheGen = $data['g'];
+        }
     }
     public function __unserialize(array $data): void
     {
@@ -440,6 +471,9 @@ class IMP_Search_Query implements Serializable
         }
         if (isset($data['m'])) {
             $this->_mboxes = $data['m'];
+        }
+        if (isset($data['g'])) {
+            $this->_cacheGen = $data['g'];
         }
     }
 }


### PR DESCRIPTION
# Fix stale IMP search results after delete/move/expunge

## Summary

- Invalidate virtual search mailboxes when underlying IMAP folders change (delete, move, expunge).
- Tie search viewport cache IDs to a per-query generation counter so `changed()` detects stale search results.
- Handle unresolved browser UIDs gracefully when opening a message from outdated search results.

## Problem

When messages were deleted from the inbox (moved to Trash or expunged), IMP search could still list them. Clicking such a stale result caused fatal errors in `horde.log`:

```
PHP ERROR: Attempt to read property "imp_imap" on null
Error: Call to a member function fetch() on null in Contents.php
```

Root cause: search results are stored as a **virtual mailbox** (`impsearch…`) in the session. That list was cached with a **static cache ID** (`'1'`) that never changed when underlying folders were modified. Additionally, `IMP_Ajax_Application::changed()` skipped automatic refresh for search mailboxes unless `forceUpdate` was set.

Stale browser BUIDs could no longer be resolved to mailbox/UID pairs (`fromBuids()` returned empty indices), leaving `getMailbox()` as `null` and crashing `IMP_Contents::_fetchData()`.

## Solution

### Search cache invalidation

Add `IMP_Search::invalidateMailboxes()` to rebuild affected search/virtual-folder lists when folder contents change. Called from:

- `IMP_Indices::delete()` — after successful delete or move-to-trash
- `IMP_Indices::copy()` — on `move`
- `IMP_Mailbox::expunge()`

Only mailboxes actually modified are tracked; invalidation runs only after successful IMAP operations.

### Per-query cache generation

Add a `_cacheGen` counter on `IMP_Search_Query`, bumped by `invalidateCache()`. Search mailbox `_getCacheID()` now includes this generation alongside sort/hide-deleted preferences, so the viewport cache ID changes when results are invalidated.

Remove the search-only exception in `IMP_Ajax_Application::changed()`. Re-check `changed()` in `deleteMsgs()` after deletion so the viewport refreshes when the search cache ID has moved.

### Defensive message load

In `IMP_Contents::_fetchData()`, throw `IMP_Exception` when indices resolve to no mailbox (before the IMAP `try` block). `showMessage()` already catches this and refreshes the viewport instead of fatalling.

## Files changed

- `lib/Search/Query.php` — cache generation counter, serialization
- `lib/Search.php` — `invalidateMailboxes()`, `_queryAffected()`
- `lib/Mailbox.php` — dynamic search `_getCacheID()`, expunge hook
- `lib/Indices.php` — invalidate on delete/move
- `lib/Ajax/Application.php` — remove search `changed()` bypass, re-check after delete
- `lib/Contents.php` — guard against unresolved BUIDs

## Test plan

- [ ] Run a quick search in INBOX; delete a result from INBOX (move to Trash). Re-open the search: deleted message must no longer appear.
- [ ] Repeat with advanced search scoped to INBOX only and with “all mailboxes”.
- [ ] Delete from Trash (expunge). Confirm expunged messages disappear from any active search that included Trash.
- [ ] Move messages between folders via drag-and-drop; confirm searches covering source or target folders refresh.
- [ ] Click a search result immediately after delete (race/stale BUID): expect “message does not exist” notice, not a PHP fatal in `horde.log`.
- [ ] Confirm no `$sortpref` warnings in `horde.log` when opening or refreshing search mailboxes.
- [ ] Sort order / hide-deleted toggle on a search mailbox still triggers a viewport refresh.
