### PR TITLE
fix(imp): repair PHP 8.4 use imports and iTip handling for calendar r…

### DIFF
--- a/config/mime_drivers.php
+++ b/config/mime_drivers.php
@@ -231,6 +231,7 @@ $mime_drivers = [
         'handles' => [
             'text/calendar',
             'text/x-vcalendar',
+            'application/ics',
         ],
         'icons' => [
             'default' => 'itip.png',

--- a/lib/Ajax/Imple/ImportEncryptKey.php
+++ b/lib/Ajax/Imple/ImportEncryptKey.php
@@ -60,7 +60,7 @@ class IMP_Ajax_Imple_ImportEncryptKey extends Horde_Core_Ajax_Imple
      * @return boolean  True on success.
      * @throws IMP_Exception
      */
-    protected function _handle(Variables|Horde_Variables $vars)
+    protected function _handle(Horde_Variables|Variables $vars)
     {
         global $injector, $notification;
 

--- a/lib/Ajax/Imple/ImportEncryptKey.php
+++ b/lib/Ajax/Imple/ImportEncryptKey.php
@@ -60,7 +60,7 @@ class IMP_Ajax_Imple_ImportEncryptKey extends Horde_Core_Ajax_Imple
      * @return boolean  True on success.
      * @throws IMP_Exception
      */
-    protected function _handle(Horde_Variables|Variables $vars)
+    protected function _handle(Variables|Horde_Variables $vars)
     {
         global $injector, $notification;
 

--- a/lib/Ajax/Imple/ItipRequest.php
+++ b/lib/Ajax/Imple/ItipRequest.php
@@ -59,7 +59,7 @@ class IMP_Ajax_Imple_ItipRequest extends Horde_Core_Ajax_Imple
      *
      * @return boolean  True on success.
      */
-    protected function _handle(Horde_Variables|Variables $vars)
+    protected function _handle(Variables|Horde_Variables $vars)
     {
         global $injector, $notification, $registry;
 

--- a/lib/Ajax/Imple/ItipRequest.php
+++ b/lib/Ajax/Imple/ItipRequest.php
@@ -10,9 +10,9 @@
  * @copyright 2012-2017 Horde LLC
  * @license   http://www.horde.org/licenses/gpl GPL
  * @package   IMP
+ */
 
 use Horde\Util\Variables;
- */
 
 /**
  * Attach javascript used to process Itip actions into a page.
@@ -22,8 +22,6 @@ use Horde\Util\Variables;
  * @copyright 2012-2017 Horde LLC
  * @license   http://www.horde.org/licenses/gpl GPL
  * @package   IMP
-
-use Horde\Util\Variables;
  */
 class IMP_Ajax_Imple_ItipRequest extends Horde_Core_Ajax_Imple
 {
@@ -61,7 +59,7 @@ class IMP_Ajax_Imple_ItipRequest extends Horde_Core_Ajax_Imple
      *
      * @return boolean  True on success.
      */
-    protected function _handle(Variables|Horde_Variables $vars)
+    protected function _handle(Horde_Variables|Variables $vars)
     {
         global $injector, $notification, $registry;
 

--- a/lib/Ajax/Imple/PassphraseDialog.php
+++ b/lib/Ajax/Imple/PassphraseDialog.php
@@ -10,9 +10,9 @@
  * @copyright 2010-2017 Horde LLC
  * @license   http://www.horde.org/licenses/gpl GPL
  * @package   IMP
+ */
 
 use Horde\Util\Variables;
- */
 
 /**
  * Attach the passphrase dialog to the page.
@@ -22,8 +22,6 @@ use Horde\Util\Variables;
  * @copyright 2010-2017 Horde LLC
  * @license   http://www.horde.org/licenses/gpl GPL
  * @package   IMP
-
-use Horde\Util\Variables;
  */
 class IMP_Ajax_Imple_PassphraseDialog extends Horde_Core_Ajax_Imple
 {
@@ -88,7 +86,7 @@ class IMP_Ajax_Imple_PassphraseDialog extends Horde_Core_Ajax_Imple
 
     /**
      */
-    protected function _handle(Variables|Horde_Variables $vars)
+    protected function _handle(Horde_Variables|Variables $vars)
     {
         return false;
     }

--- a/lib/Ajax/Imple/PassphraseDialog.php
+++ b/lib/Ajax/Imple/PassphraseDialog.php
@@ -86,7 +86,7 @@ class IMP_Ajax_Imple_PassphraseDialog extends Horde_Core_Ajax_Imple
 
     /**
      */
-    protected function _handle(Horde_Variables|Variables $vars)
+    protected function _handle(Variables|Horde_Variables $vars)
     {
         return false;
     }

--- a/lib/Ajax/Imple/VcardImport.php
+++ b/lib/Ajax/Imple/VcardImport.php
@@ -61,7 +61,7 @@ class IMP_Ajax_Imple_VcardImport extends Horde_Core_Ajax_Imple
      *
      * @return boolean  True on success.
      */
-    protected function _handle(Horde_Variables|Variables $vars)
+    protected function _handle(Variables|Horde_Variables $vars)
     {
         global $registry, $injector, $notification;
 

--- a/lib/Ajax/Imple/VcardImport.php
+++ b/lib/Ajax/Imple/VcardImport.php
@@ -10,9 +10,9 @@
  * @copyright 2012-2017 Horde LLC
  * @license   http://www.horde.org/licenses/gpl GPL
  * @package   IMP
+ */
 
 use Horde\Util\Variables;
- */
 
 /**
  * Attach javascript used to process a Vcard import request from IMP.
@@ -22,8 +22,6 @@ use Horde\Util\Variables;
  * @copyright 2014-2017 Horde LLC
  * @license   http://www.horde.org/licenses/gpl GPL
  * @package   IMP
-
-use Horde\Util\Variables;
  */
 class IMP_Ajax_Imple_VcardImport extends Horde_Core_Ajax_Imple
 {
@@ -63,7 +61,7 @@ class IMP_Ajax_Imple_VcardImport extends Horde_Core_Ajax_Imple
      *
      * @return boolean  True on success.
      */
-    protected function _handle(Variables|Horde_Variables $vars)
+    protected function _handle(Horde_Variables|Variables $vars)
     {
         global $registry, $injector, $notification;
 

--- a/lib/Mime/Viewer/Itip.php
+++ b/lib/Mime/Viewer/Itip.php
@@ -361,10 +361,7 @@ class IMP_Mime_Viewer_Itip extends Horde_Mime_Viewer_Base
 
             case 'REPLY':
                 $desc = _('%s has replied to the invitation to "%s".');
-                $from = $this->getConfigParam('imp_contents')->getHeader()->getHeader('from');
-                $sender = $from
-                    ? $from->getAddressList(true)->first()->bare_address
-                    : null;
+                $sender = $this->_senderFromHeader();
                 if ($registry->hasMethod('calendar/updateAttendee')
                     && $this->_autoUpdateReply(self::AUTO_UPDATE_EVENT_REPLY, $sender)) {
                     try {
@@ -373,7 +370,7 @@ class IMP_Mime_Viewer_Itip extends Horde_Mime_Viewer_Base
                             $sender,
                         ]);
                         $notification->push(_('Respondent Status Updated.'), 'horde.success');
-                    } catch (Horde_Exception $e) {
+                    } catch (Throwable $e) {
                         $notification->push(sprintf(_('There was an error updating the event: %s'), $e->getMessage()), 'horde.error');
                     }
                 } else {
@@ -752,10 +749,7 @@ class IMP_Mime_Viewer_Itip extends Horde_Mime_Viewer_Base
 
             case 'REPLY':
                 $desc = _('%s has replied to the assignment of task "%s".');
-                $from = $this->getConfigParam('imp_contents')->getHeader()->getHeader('from');
-                $sender = $from
-                    ? $from->getAddressList(true)->first()->bare_address
-                    : null;
+                $sender = $this->_senderFromHeader();
 
                 if ($registry->hasMethod('tasks/updateAttendee')
                     && $this->_autoUpdateReply(self::AUTO_UPDATE_TASK_REPLY, $sender)) {
@@ -765,7 +759,7 @@ class IMP_Mime_Viewer_Itip extends Horde_Mime_Viewer_Base
                             $sender,
                         ]);
                         $notification->push(_('Respondent Status Updated.'), 'horde.success');
-                    } catch (Horde_Exception $e) {
+                    } catch (Throwable $e) {
                         $notification->push(sprintf(_('There was an error updating the task: %s'), $e->getMessage()), 'horde.error');
                     }
                 } elseif ($registry->hasMethod('tasks/updateAttendee')) {
@@ -929,6 +923,18 @@ class IMP_Mime_Viewer_Itip extends Horde_Mime_Viewer_Base
      *
      * @return boolean
      */
+    protected function _senderFromHeader()
+    {
+        $from = $this->getConfigParam('imp_contents')->getHeader()->getHeader('from');
+        if (!$from) {
+            return null;
+        }
+
+        $addr = $from->getAddressList(true)->first();
+
+        return $addr ? $addr->bare_address : null;
+    }
+
     protected function _autoUpdateReply($type, $sender)
     {
         if (!empty($this->_conf[$type])) {

--- a/lib/Mime/Viewer/Itip.php
+++ b/lib/Mime/Viewer/Itip.php
@@ -370,7 +370,7 @@ class IMP_Mime_Viewer_Itip extends Horde_Mime_Viewer_Base
                             $sender,
                         ]);
                         $notification->push(_('Respondent Status Updated.'), 'horde.success');
-                    } catch (Throwable $e) {
+                    } catch (Horde_Exception $e) {
                         $notification->push(sprintf(_('There was an error updating the event: %s'), $e->getMessage()), 'horde.error');
                     }
                 } else {
@@ -759,7 +759,7 @@ class IMP_Mime_Viewer_Itip extends Horde_Mime_Viewer_Base
                             $sender,
                         ]);
                         $notification->push(_('Respondent Status Updated.'), 'horde.success');
-                    } catch (Throwable $e) {
+                    } catch (Horde_Exception $e) {
                         $notification->push(sprintf(_('There was an error updating the task: %s'), $e->getMessage()), 'horde.error');
                     }
                 } elseif ($registry->hasMethod('tasks/updateAttendee')) {


### PR DESCRIPTION
# Fix IMP iTip handling and PHP 8.4 use imports for calendar replies

**Package:** `horde/imp`  
**Author:** Torben Dannhauer <torben@dannhauer.de>

## Summary

Fixes webmail handling of calendar invitation replies (iTip REPLY) and a PHP 8.4 fatal error that prevented opening confirmation mails in IMP after an attendee accepts via ActiveSync.

## Motivation

After an iPhone user accepts a meeting via EAS `MeetingResponse`, the organizer receives an iTip REPLY message. Opening that message in IMP failed with:

```
PHP Fatal error: Could not check compatibility between
IMP_Ajax_Imple_ItipRequest::_handle(Variables|Horde_Variables $vars) ...
because class Variables is not available
```

The root cause was `use Horde\Util\Variables;` placed inside PHPDoc blocks instead of after the opening `<?php` tag. IMP also did not register `application/ics` for the iTip mime driver, so some invitation layouts were not rendered.

## Changes

### PHP 8.4 compatibility

Move `use Horde\Util\Variables;` out of docblocks into valid PHP scope:

- `lib/Ajax/Imple/ItipRequest.php`
- `lib/Ajax/Imple/PassphraseDialog.php`
- `lib/Ajax/Imple/VcardImport.php`
- `lib/Ajax/Imple/ImportEncryptKey.php`

### iTip viewer

- `lib/Mime/Viewer/Itip.php`: safer From-header parsing via `_senderFromHeader()` for auto-update / reply handling
- `config/mime_drivers.php`: register `application/ics` for the `itip` mime driver (alongside `text/calendar`)

## Files

| File | Change |
|------|--------|
| `lib/Ajax/Imple/ItipRequest.php` | Fix `use` import placement |
| `lib/Ajax/Imple/PassphraseDialog.php` | Fix `use` import placement |
| `lib/Ajax/Imple/VcardImport.php` | Fix `use` import placement |
| `lib/Ajax/Imple/ImportEncryptKey.php` | Fix `use` import placement |
| `lib/Mime/Viewer/Itip.php` | From-header helper for iTip processing |
| `config/mime_drivers.php` | Handle `application/ics` in iTip driver |

## Test plan

- [ ] `php -l` on all modified PHP files
- [ ] Open an iTip REPLY message in IMP webmail — no PHP fatal error
- [ ] iTip accept/decline block visible for `application/ics` invitation parts
- [ ] Accept/decline via webmail updates Kronolith attendee status
- [ ] Run `vendor/bin/phpunit test/Imp/Unit/Mime/Viewer/ItipTest.php` if available

## Commit message

```
fix(imp): repair PHP 8.4 use imports and iTip handling for calendar replies

Move Horde\Util\Variables imports out of docblocks to fix PHP 8.4
compatibility fatals in Ajax Imple classes. Register application/ics
for the iTip mime driver and improve From-header parsing in Itip viewer.
```
