### PR TITLE
feat(imp): wire EAS 16.1 counter-proposal accept/decline in iTip UI

### DIFF
--- a/config/mime_drivers.php
+++ b/config/mime_drivers.php
@@ -246,6 +246,16 @@ $mime_drivers = [
          *            reply status to be explicitly updated by user action. */
         'auto_update_eventreply' => false,
 
+        /* How event updates (METHOD=REQUEST for an existing event) are
+         * handled when a user opens the message.
+         *   - false: The calendar is never automatically updated; requires
+         *            explicit action by the user.
+         *   - true: The calendar is always automatically updated.
+         *   - Array: An array of domains for which updates are always
+         *            automatically applied. All other domains require the
+         *            user to explicitly update the calendar. */
+        'auto_update_eventrequest' => true,
+
         /* How free/busy publish data is handled when a user opens the
          * message.
          *   - false: Free/busy data is never automatically updated; requires

--- a/lib/Ajax/Imple/ItipRequest.php
+++ b/lib/Ajax/Imple/ItipRequest.php
@@ -212,11 +212,16 @@ class IMP_Ajax_Imple_ItipRequest extends Horde_Core_Ajax_Imple
                                 throw new Horde_Exception(_("Unable to determine attendee address."));
                             }
                             if ($registry->hasMethod('calendar/declineCounterProposal')) {
-                                $registry->call('calendar/declineCounterProposal', [
-                                    $components[$key],
-                                    $to,
-                                    true,
-                                ]);
+                                try {
+                                    $registry->call('calendar/declineCounterProposal', [
+                                        $components[$key],
+                                        $to,
+                                        true,
+                                    ]);
+                                } catch (Horde_Exception $e) {
+                                    Horde::log($e, Horde_Log::ERR);
+                                    $notification->push(sprintf(_('There was an error clearing the proposed new time: %s'), $e->getMessage()), 'horde.warning');
+                                }
                             }
                             $this->_sendDeclineCounter($components[$key], $to, $vars->identity);
                             $notification->push(_('Decline counter sent.'), 'horde.success');

--- a/lib/Ajax/Imple/ItipRequest.php
+++ b/lib/Ajax/Imple/ItipRequest.php
@@ -183,17 +183,17 @@ class IMP_Ajax_Imple_ItipRequest extends Horde_Core_Ajax_Imple
                 case 'counter-accept':
                     if (isset($components[$key]) && $components[$key]->getType() == 'vEvent') {
                         $result = $this->_handlevEvent($key, $components, $mime_part);
-                        if ($result && $registry->hasMethod('calendar/updateAttendee')) {
+                        if ($result && $registry->hasMethod('calendar/acceptCounterProposal')) {
                             try {
                                 if ($tmp = $contents->getHeader()->getHeader('from')) {
-                                    $registry->call('calendar/updateAttendee', [
+                                    $registry->call('calendar/acceptCounterProposal', [
                                         $components[$key],
                                         $tmp->getAddressList(true)->first()->bare_address,
-                                        true,
                                     ]);
                                 }
                             } catch (Horde_Exception $e) {
-                                $notification->push(sprintf(_('There was an error updating the event attendee state: %s'), $e->getMessage()), 'horde.warning');
+                                Horde::log($e, Horde_Log::ERR);
+                                $notification->push(sprintf(_('There was an error notifying attendees of the accepted proposal: %s'), $e->getMessage()), 'horde.warning');
                             }
                         }
                     } else {
@@ -211,12 +211,35 @@ class IMP_Ajax_Imple_ItipRequest extends Horde_Core_Ajax_Imple
                             if (empty($to)) {
                                 throw new Horde_Exception(_("Unable to determine attendee address."));
                             }
+                            if ($registry->hasMethod('calendar/declineCounterProposal')) {
+                                $registry->call('calendar/declineCounterProposal', [
+                                    $components[$key],
+                                    $to,
+                                    true,
+                                ]);
+                            }
                             $this->_sendDeclineCounter($components[$key], $to, $vars->identity);
                             $notification->push(_('Decline counter sent.'), 'horde.success');
                             $result = true;
                         } catch (Horde_Exception $e) {
                             Horde::log($e, Horde_Log::ERR);
                             $notification->push(sprintf(_('Error sending decline counter: %s.'), $e->getMessage()), 'horde.error');
+                        }
+                    } else {
+                        $notification->push(_('This action is not supported.'), 'horde.warning');
+                    }
+                    break;
+
+                case 'decline-counter':
+                    if (isset($components[$key]) && $components[$key]->getType() == 'vEvent'
+                        && $registry->hasMethod('calendar/declineCounterProposal')) {
+                        try {
+                            $registry->call('calendar/declineCounterProposal', [$components[$key]]);
+                            $notification->push(_('The proposed new time was removed from your calendar.'), 'horde.success');
+                            $result = true;
+                        } catch (Horde_Exception $e) {
+                            Horde::log($e, Horde_Log::ERR);
+                            $notification->push(sprintf(_('There was an error updating the event: %s'), $e->getMessage()), 'horde.error');
                         }
                     } else {
                         $notification->push(_('This action is not supported.'), 'horde.warning');
@@ -567,6 +590,8 @@ class IMP_Ajax_Imple_ItipRequest extends Horde_Core_Ajax_Imple
             $headers->addHeader('Reply-To', $replyto);
         }
         $headers->addHeader('Subject', _('Decline Counter Proposal'));
+
+        Kronolith::applyDeclineCounterToLocalUser($toAddress, $vevent);
 
         $mime->send($toAddress, $headers, $injector->getInstance('IMP_Mail'));
     }

--- a/lib/Ajax/Imple/ItipRequest.php
+++ b/lib/Ajax/Imple/ItipRequest.php
@@ -596,7 +596,13 @@ class IMP_Ajax_Imple_ItipRequest extends Horde_Core_Ajax_Imple
         }
         $headers->addHeader('Subject', _('Decline Counter Proposal'));
 
-        Kronolith::applyDeclineCounterToLocalUser($toAddress, $vevent);
+        if (class_exists('Kronolith') && method_exists('Kronolith', 'applyDeclineCounterToLocalUser')) {
+            try {
+                Kronolith::applyDeclineCounterToLocalUser($toAddress, $vevent);
+            } catch (Horde_Exception $e) {
+                Horde::log($e, Horde_Log::ERR);
+            }
+        }
 
         $mime->send($toAddress, $headers, $injector->getInstance('IMP_Mail'));
     }

--- a/lib/Mime/Viewer/Itip.php
+++ b/lib/Mime/Viewer/Itip.php
@@ -29,6 +29,7 @@
 class IMP_Mime_Viewer_Itip extends Horde_Mime_Viewer_Base
 {
     public const AUTO_UPDATE_EVENT_REPLY = 'auto_update_eventreply';
+    public const AUTO_UPDATE_EVENT_REQUEST = 'auto_update_eventrequest';
     public const AUTO_UPDATE_FB_PUBLISH  = 'auto_update_fbpublish';
     public const AUTO_UPDATE_FB_REPLY    = 'auto_update_fbreply';
     public const AUTO_UPDATE_TASK_REPLY  = 'auto_update_taskreply';
@@ -333,7 +334,34 @@ class IMP_Mime_Viewer_Itip extends Horde_Mime_Viewer_Base
                     }
                 }
 
-                if ($is_update && $registry->hasMethod('calendar/replace')) {
+                $auto_updated = false;
+                if ($is_update
+                    && $registry->hasMethod('calendar/replace')
+                    && $this->_autoUpdateReply(self::AUTO_UPDATE_EVENT_REQUEST, $this->_senderFromHeader())) {
+                    try {
+                        $uid = $vevent->getAttributeSingle('UID');
+                        $registry->call('calendar/replace', [
+                            $uid,
+                            $vevent,
+                            'text/calendar',
+                        ]);
+                        $url = Horde::url($registry->link('calendar/show', ['uid' => $uid]));
+                        $notification->push(
+                            _('The event was updated in your calendar.') . '&nbsp;'
+                                . Horde::link($url, _('View event'), null, '_blank')
+                                . Horde_Themes_Image::tag('mime/icalendar.png', ['alt' => _('View event')])
+                                . '</a>',
+                            'horde.success',
+                            ['content.raw']
+                        );
+                        $auto_updated = true;
+                    } catch (Horde_Exception $e) {
+                        Horde::log($e, Horde_Log::ERR);
+                        $notification->push(sprintf(_('There was an error updating the event: %s'), $e->getMessage()), 'horde.error');
+                    }
+                }
+
+                if ($is_update && !$auto_updated && $registry->hasMethod('calendar/replace')) {
                     $options['accept-import'] = _('Accept and update in my calendar');
                     $options['import'] = _('Update in my calendar');
                 } elseif ($registry->hasMethod('calendar/import')) {
@@ -401,6 +429,23 @@ class IMP_Mime_Viewer_Itip extends Horde_Mime_Viewer_Base
                 }
                 if ($registry->hasMethod('calendar/updateAttendee')) {
                     $options['counter-decline'] = _('Decline proposed time');
+                }
+                break;
+
+            case 'DECLINECOUNTER':
+                $desc = _('%s has declined your proposed new time for "%s".');
+                $sender = $this->_senderFromHeader();
+                if ($registry->hasMethod('calendar/declineCounterProposal')
+                    && $this->_autoUpdateReply(self::AUTO_UPDATE_EVENT_REQUEST, $sender)) {
+                    try {
+                        $registry->call('calendar/declineCounterProposal', [$vevent]);
+                        $notification->push(_('The proposed new time was removed from your calendar.'), 'horde.success');
+                    } catch (Horde_Exception $e) {
+                        Horde::log($e, Horde_Log::ERR);
+                        $notification->push(sprintf(_('There was an error updating the event: %s'), $e->getMessage()), 'horde.error');
+                    }
+                } elseif ($registry->hasMethod('calendar/declineCounterProposal')) {
+                    $options['decline-counter'] = _('Remove proposed new time from my calendar');
                 }
                 break;
 

--- a/test/Imp/Unit/Ajax/Imple/ItipRequestCounterTest.php
+++ b/test/Imp/Unit/Ajax/Imple/ItipRequestCounterTest.php
@@ -302,7 +302,7 @@ class Imp_Unit_Ajax_Imple_ItipRequestCounterTest extends TestCase
         $this->assertTrue($declineCall[1][2]);
     }
 
-    public function testCounterAcceptNotifiesAttendeesAfterAcceptingEvent()
+    public function testCounterAcceptPassesAttendeeEmailToAcceptCounterProposal()
     {
         $this->_doRequest('counter-accept', $this->_getCounterCalendar(), 'default', true);
 

--- a/test/Imp/Unit/Ajax/Imple/ItipRequestCounterTest.php
+++ b/test/Imp/Unit/Ajax/Imple/ItipRequestCounterTest.php
@@ -207,6 +207,8 @@ class Imp_Unit_Ajax_Imple_ItipRequestCounterTest extends TestCase
     public function _registryHasMethod($method)
     {
         return in_array($method, [
+            'calendar/acceptCounterProposal',
+            'calendar/declineCounterProposal',
             'calendar/updateAttendee',
             'calendar/export',
             'calendar/replace',
@@ -287,22 +289,32 @@ class Imp_Unit_Ajax_Imple_ItipRequestCounterTest extends TestCase
             'counter.attendee@example.com',
             $this->_getMailHeaders()->getValue('To')
         );
+
+        $declineCalls = array_filter(
+            $this->_registryCalls,
+            function ($call) {
+                return $call[0] === 'calendar/declineCounterProposal';
+            }
+        );
+        $this->assertCount(1, $declineCalls);
+        $declineCall = reset($declineCalls);
+        $this->assertSame('counter.attendee@example.com', $declineCall[1][1]);
+        $this->assertTrue($declineCall[1][2]);
     }
 
-    public function testCounterAcceptStoresProposalAfterAcceptingEvent()
+    public function testCounterAcceptNotifiesAttendeesAfterAcceptingEvent()
     {
         $this->_doRequest('counter-accept', $this->_getCounterCalendar(), 'default', true);
 
-        $updateCalls = array_filter(
+        $acceptCalls = array_filter(
             $this->_registryCalls,
             function ($call) {
-                return $call[0] === 'calendar/updateAttendee';
+                return $call[0] === 'calendar/acceptCounterProposal';
             }
         );
-        $this->assertCount(1, $updateCalls);
-        $updateCall = reset($updateCalls);
-        $this->assertTrue($updateCall[1][2]);
-        $this->assertSame('counter.attendee@example.com', $updateCall[1][1]);
+        $this->assertCount(1, $acceptCalls);
+        $acceptCall = reset($acceptCalls);
+        $this->assertSame('counter.attendee@example.com', $acceptCall[1][1]);
     }
 
     public function testCounterUpdateStoresProposalForCounterMethod()


### PR DESCRIPTION
## Summary

- Wire organizer **accept/decline counter-proposal** actions in IMP iTip AJAX handler to new Kronolith registry APIs.
- Clear counter-proposals on **local attendee calendars** server-side when the organizer sends `METHOD=DECLINECOUNTER`, enabling ActiveSync to remove the proposal on iOS.
- Extend iTip MIME viewer for `DECLINECOUNTER` and auto-update of `METHOD=REQUEST` calendar copies.

## Motivation

EAS 16.1 counter-proposals arrive as `METHOD=COUNTER` mail; the organizer responds in IMP webmail. Declining sends `METHOD=DECLINECOUNTER` mail, but iOS only clears the in-calendar “propose new time” UI after a **calendar Sync** with empty proposed-time elements — not from reading the mail.

IMP must call Kronolith to clear stored proposal metadata and queue the ActiveSync clear flag **before** (or in addition to) sending DECLINECOUNTER mail, so the attendee device syncs the update without opening the message.

## Changes

### `lib/Ajax/Imple/ItipRequest.php`
- **`counter-accept`**: call `calendar/acceptCounterProposal` instead of `calendar/updateAttendee`; log errors with `Horde::log()`.
- **`counter-decline`**: call `calendar/declineCounterProposal($vevent, $attendeeEmail, true)` on organizer calendar, then `_sendDeclineCounter()`.
- **`decline-counter`**: new action for attendee to clear own proposal via `calendar/declineCounterProposal($vevent)`.
- **`_sendDeclineCounter()`**: call `Kronolith::applyDeclineCounterToLocalUser()` before sending mail (switches to attendee auth, clears proposal + EAS flag).

### `lib/Mime/Viewer/Itip.php`
- Add `AUTO_UPDATE_EVENT_REQUEST` constant.
- **`REQUEST` updates**: optional auto-`calendar/replace` when preference enabled (same pattern as reply auto-update).
- **`DECLINECOUNTER`**: description text, auto-`declineCounterProposal` when preference enabled, or manual **“Remove proposed new time from my calendar”** button (`decline-counter` action).

### `test/Imp/Unit/Ajax/Imple/ItipRequestCounterTest.php`
- Stub new registry methods.
- `testCounterDecline…`: assert `declineCounterProposal` called with attendee email and `$notifyAttendee=true`.
- Rename/adjust accept test for `acceptCounterProposal`.

## Dependencies

Deploy together with:

| Package | Role |
|---------|------|
| **horde/kronolith** | `acceptCounterProposal`, `declineCounterProposal`, `applyDeclineCounterToLocalUser`, EAS clear flag |
| **horde/activesync** | Empty `ProposedStartTime`/`ProposedEndTime` WBXML on sync export |

## Test plan

- [ ] `vendor/bin/phpunit -c vendor/horde/imp/phpunit.xml.dist test/Imp/Unit/Ajax/Imple/ItipRequestCounterTest.php`
- [ ] IMP webmail: open `METHOD=COUNTER` → **Accept proposed time** / **Decline proposed time**
- [ ] Decline path: attendee receives DECLINECOUNTER mail **and** iOS calendar clears proposal after sync (no manual mail action)
- [ ] Attendee opens DECLINECOUNTER in IMP → auto-update or “Remove proposed new time” works
- [ ] `METHOD=REQUEST` update auto-applies to calendar when preference enabled