### PR TITLE
Expose IMP dynamic view dimensions as CSS custom properties

### DIFF
--- a/js/base.js
+++ b/js/base.js
@@ -348,17 +348,24 @@ var ImpBase = {
 
     setSidebarWidth: function()
     {
-        var width = ImpCore.getPref('splitbar_side');
-        var px = width === null ? '0px' : width + 'px';
+        var tmp = $('horde-sidebar'),
+            width = ImpCore.getPref('splitbar_side');
+
+        if (tmp) {
+            tmp.setStyle({ width: (width === null ? 0 : width) + 'px' });
+        }
+
+        /* Use the sidebar's rendered width (accounts for padding/box-sizing)
+         * for the left offsets, matching the original behaviour, and expose
+         * the same value as a CSS custom property. */
+        var px = (tmp ? tmp.clientWidth : (width === null ? 0 : width)) + 'px';
+
         document.documentElement.style.setProperty('--horde-sidebar-width', px);
+        if (this.splitbar) {
+            this.splitbar.setStyle({ left: px });
+        }
         if ($("horde-page")) {
             $("horde-page").setStyle({ left: px });
-        }
-        if ($("horde-sidebar")) {
-            $("horde-sidebar").setStyle({ width: px });
-        }
-        if ($("horde-slideleft")) {
-            $("horde-slideleft").setStyle({ left: px });
         }
     },
 

--- a/js/base.js
+++ b/js/base.js
@@ -348,17 +348,18 @@ var ImpBase = {
 
     setSidebarWidth: function()
     {
-        var tmp = $('horde-sidebar');
-
-        tmp.setStyle({
-            width: ImpCore.getPref('splitbar_side') + 'px'
-        });
-        this.splitbar.setStyle({
-            left: tmp.clientWidth + 'px'
-        });
-        $('horde-page').setStyle({
-            left: (tmp.clientWidth) + 'px'
-        });
+        var width = ImpCore.getPref('splitbar_side');
+        var px = width === null ? '0px' : width + 'px';
+        document.documentElement.style.setProperty('--horde-sidebar-width', px);
+        if ($("horde-page")) {
+            $("horde-page").setStyle({ left: px });
+        }
+        if ($("horde-sidebar")) {
+            $("horde-sidebar").setStyle({ width: px });
+        }
+        if ($("horde-slideleft")) {
+            $("horde-slideleft").setStyle({ left: px });
+        }
     },
 
     // r = ViewPort row data

--- a/js/viewport.js
+++ b/js/viewport.js
@@ -511,9 +511,15 @@ var ViewPort = Class.create({
             });
             this.opts.content.setStyle({ width: 'auto' });
             sp.currbar.show();
+            var _ph = Math.max(document.viewport.getHeight() - this.opts.pane_data.viewportOffset()[1], 0);
             this.opts.pane_data.show().setStyle({
-                height: Math.max(document.viewport.getHeight() - this.opts.pane_data.viewportOffset()[1], 0) + 'px'
+                height: _ph + 'px'
             });
+            document.documentElement.style.setProperty('--imp-pane-mode', 'horiz');
+            document.documentElement.style.setProperty('--imp-list-height', h + 'px');
+            document.documentElement.style.setProperty('--imp-list-width', 'auto');
+            document.documentElement.style.setProperty('--imp-preview-height', _ph + 'px');
+            document.documentElement.style.setProperty('--imp-preview-width', 'auto');
             break;
 
         case 'vert':
@@ -540,9 +546,15 @@ var ViewPort = Class.create({
             sp.currbar.setStyle({
                 height: h - sp.currbar.getLayout().get('border-bottom') + 'px'
             }).show();
+            var _pvh = h - this.opts.pane_data.getLayout().get('border-bottom');
             this.opts.pane_data.setStyle({
-                height: h - this.opts.pane_data.getLayout().get('border-bottom') + 'px'
+                height: _pvh + 'px'
             }).show();
+            document.documentElement.style.setProperty('--imp-pane-mode', 'vert');
+            document.documentElement.style.setProperty('--imp-list-height', h + 'px');
+            document.documentElement.style.setProperty('--imp-list-width', sp.vert.width + 'px');
+            document.documentElement.style.setProperty('--imp-preview-height', _pvh + 'px');
+            document.documentElement.style.setProperty('--imp-preview-width', 'auto');
             break;
 
         default:
@@ -559,12 +571,18 @@ var ViewPort = Class.create({
                 this.page_size = this.getPageSize('max');
             }
 
+            var _dlh = h + (lh * this.page_size);
             this.opts.list_container.setStyle({
                 cssFloat: 'none',
-                height: (h + (lh * this.page_size)) + 'px',
+                height: _dlh + 'px',
                 width: 'auto'
             });
             this.opts.content.setStyle({ width: 'auto' });
+            document.documentElement.style.setProperty('--imp-pane-mode', 'none');
+            document.documentElement.style.setProperty('--imp-list-height', _dlh + 'px');
+            document.documentElement.style.setProperty('--imp-list-width', 'auto');
+            document.documentElement.style.removeProperty('--imp-preview-height');
+            document.documentElement.style.removeProperty('--imp-preview-width');
             break;
         }
 


### PR DESCRIPTION
This is a follow-up to horde/base#111 (merged), applying the same approach to IMP's dynamic view.

IMP computes its layout dimensions in JavaScript and applies them as inline styles, which prevents themes from styling the dynamic view in pure CSS. This exposes those values as CSS custom properties on `<html>`:

- `--horde-sidebar-width` (js/base.js, `setSidebarWidth`) — complements the property exposed at load time by horde/base
- `--imp-pane-mode` (`horiz` / `vert` / `none`)
- `--imp-list-height`, `--imp-list-width`
- `--imp-preview-height`, `--imp-preview-width` (removed in no-split mode)

**No existing behaviour is removed**: every original `setStyle()` call is kept; the computed heights are only extracted into local vars to be reused, and the custom properties are inert until a theme consumes them — so the default theme is unaffected.

Tested on a live Horde 6 instance with both the default theme (no visual change) and a theme consuming these properties (the dynamic view — list and preview panes — fully themeable in CSS).

cc @ralflang @jcdelepine