### PR TITLE
fix(imp): repair HTML view-in-popup after Horde 6 CSRF tokens

### DIFF
--- a/lib/Contents.php
+++ b/lib/Contents.php
@@ -1004,16 +1004,21 @@ class IMP_Contents
                 : null;
         }
 
-        $url = Horde::popupJs(Horde::url('view.php'), [
-            'menu' => true,
-            'onload' => empty($options['onload']) ? 'IMP_JS.resizePopup' : $options['onload'],
-            'params' => $this->_urlViewParams($mime_part, $actionID, $options['params'] ?? []),
-            'urlencode' => true,
-        ]);
+        $params = $this->_urlViewParams($mime_part, $actionID, $options['params'] ?? []);
+        unset($params[IMP_Contents_View::VIEW_TOKEN_PARAM]);
+
+        $onclick = Horde::popupJs(
+            Horde::url('view.php', true)->add($params),
+            [
+                'menu' => 1,
+                'onload' => empty($options['onload']) ? 'IMP_JS.resizePopup' : $options['onload'],
+                'urlencode' => true,
+            ]
+        ) . 'return false;';
 
         return empty($options['widget'])
-            ? Horde::link('#', $options['jstext'], empty($options['css']) ? null : $options['css'], null, $url) . $text . '</a>'
-            : Horde::widget(['url' => '#', 'class' => empty($options['css']) ? null : $options['css'], 'onclick' => $url, 'title' => $text]);
+            ? Horde::link('#', $options['jstext'], empty($options['css']) ? null : $options['css'], null, $onclick) . $text . '</a>'
+            : Horde::widget(['url' => '#', 'class' => empty($options['css']) ? null : $options['css'], 'onclick' => $onclick, 'title' => $text]);
     }
 
     /**

--- a/lib/Contents/View.php
+++ b/lib/Contents/View.php
@@ -12,6 +12,9 @@
  * @package   IMP
  */
 
+use Horde\Core\Session\HordeSession;
+use Horde\Token\Exception\TokenException;
+use Horde\Token\Token;
 use Horde\Util\Variables;
 
 /**
@@ -347,7 +350,37 @@ class IMP_Contents_View
      */
     public function checkToken(Variables|Horde_Variables $vars)
     {
-        $GLOBALS['session']->checkToken($vars->get(self::VIEW_TOKEN_PARAM));
+        self::validateRequestToken($vars);
+    }
+
+    /**
+     * Validate the download/view request token.
+     *
+     * @param Horde_Variables|Variables $vars  Form variables.
+     *
+     * @throws Horde_Exception
+     */
+    public static function validateRequestToken(Variables|Horde_Variables $vars)
+    {
+        $token = $vars->get(self::VIEW_TOKEN_PARAM);
+        if (!strlen((string) $token)) {
+            $token = $vars->get('token');
+        }
+
+        $tokenService = $GLOBALS['injector']->getInstance(Token::class);
+
+        try {
+            $valid = $tokenService->isValid(
+                (string) $token,
+                HordeSession::CSRF_SEED
+            );
+        } catch (TokenException $e) {
+            throw new Horde_Exception('Invalid token!');
+        }
+
+        if (!$valid) {
+            throw new Horde_Exception('Invalid token!');
+        }
     }
 
     /* Static methods. */

--- a/lib/Dynamic/Base.php
+++ b/lib/Dynamic/Base.php
@@ -133,7 +133,7 @@ abstract class IMP_Dynamic_Base
             // URL variables
             'URI_COMPOSE' => strval(IMP_Dynamic_Compose::url()->setRaw(true)),
             'URI_MAILLOG' => strval(IMP_Dynamic_Maillog::url()->setRaw(true)),
-            'URI_VIEW' => strval(Horde::url('view.php')->add(IMP_Contents_View::addToken())),
+            'URI_VIEW' => strval(Horde::url('view.php')),
 
             // Other variables
             'disable_compose' => !IMP_Compose::canCompose(),

--- a/view.php
+++ b/view.php
@@ -33,35 +33,49 @@
  */
 
 require_once __DIR__ . '/lib/Application.php';
-Horde_Registry::appInit('imp', [
-    'session_control' => 'readonly',
-]);
+Horde_Registry::appInit('imp');
 
 $vars = $injector->getInstance('Horde_Variables');
+$res = null;
 
 /* Run through action handlers */
-switch ($vars->actionID) {
-    case 'compose_attach_preview':
-        $view_ob = new IMP_Compose_View($vars->composeCache);
-        $res = $view_ob->composeAttachPreview($vars->id, true, $vars->ctype);
-        break;
+try {
+    switch ($vars->actionID) {
+        case 'compose_attach_preview':
+            $view_ob = new IMP_Compose_View($vars->composeCache);
+            $res = $view_ob->composeAttachPreview($vars->id, true, $vars->ctype);
+            break;
 
-    case 'print_attach':
-        $view_ob = new IMP_Contents_View(new IMP_Indices_Mailbox($vars));
-        $view_ob->checkToken($vars);
-        $res = $view_ob->printAttach($vars->id);
-        break;
+        case 'print_attach':
+            IMP_Contents_View::validateRequestToken($vars);
+            $view_ob = new IMP_Contents_View(new IMP_Indices_Mailbox($vars));
+            $res = $view_ob->printAttach($vars->id);
+            break;
 
-    case 'view_attach':
-        $view_ob = new IMP_Contents_View(new IMP_Indices_Mailbox($vars));
-        $view_ob->checkToken($vars);
-        $res = $view_ob->viewAttach($vars->id, $vars->mode, $vars->autodetect, $vars->ctype);
-        break;
+        case 'view_attach':
+            IMP_Contents_View::validateRequestToken($vars);
+            $view_ob = new IMP_Contents_View(new IMP_Indices_Mailbox($vars));
+            $res = $view_ob->viewAttach($vars->id, $vars->mode, $vars->autodetect, $vars->ctype);
+            break;
 
-    case 'view_source':
-        $view_ob = new IMP_Contents_View(new IMP_Indices_Mailbox($vars));
-        $res = $view_ob->viewSource();
-        break;
+        case 'view_source':
+            $view_ob = new IMP_Contents_View(new IMP_Indices_Mailbox($vars));
+            $res = $view_ob->viewSource();
+            break;
+    }
+} catch (Horde_Exception $e) {
+    Horde::log($e, Horde_Log::ERR);
+
+    if (!headers_sent()) {
+        header('Content-Type: text/html; charset=UTF-8');
+    }
+
+    echo '<!DOCTYPE html><html><head><title>',
+        htmlspecialchars(_('Error')),
+        '</title></head><body><p>',
+        htmlspecialchars($e->getMessage()),
+        '</p></body></html>';
+    exit;
 }
 
 if (empty($res)) {


### PR DESCRIPTION
## Summary
- Harden `view.php` token validation and error handling for `view_attach` / `print_attach`.
- Stop embedding stale `view_token` values in MIME viewer popup links.
- Remove unused view token from `ImpCore.conf.URI_VIEW`.

## Motivation
Opening HTML parts in a separate window failed after Horde 6 CSRF token migration: popups lacked a valid token and `view.php` rejected the request. This complements horde/core popup.js changes that inject `token` at click time.

## Changes
- `view.php`: writable session; validate token before loading contents; HTML error page on `Horde_Exception`.
- `lib/Contents/View.php`: `validateRequestToken()` via `Horde\Token\Token` (matches AJAX).
- `lib/Contents.php`: `linkViewJS()` uses `Horde::popupJs()` without embedded `view_token`.
- `lib/Dynamic/Base.php`: `URI_VIEW` without stale token parameter.

## Dependencies
Requires horde/core PR that adds CSRF token injection to `HordePopup.popup()`.

## Test plan
- [ ] Open HTML mail in IMP; use “View HTML data in new window” — popup shows message HTML.
- [ ] Print attachment popup still works.
- [ ] `view_source` from message context menu still works.
- [ ] Invalid/expired token shows an error page in the popup, not a silent blank window.
