### PR TITLE
fix(imp): avoid undefined data key in delivery status render

### DIFF
--- a/lib/Contents.php
+++ b/lib/Contents.php
@@ -676,7 +676,9 @@ class IMP_Contents
 
         /* Don't show empty parts. */
         if (($textmode == 'inline')
-            && !empty($ret[$mime_id]) && !is_null($ret[$mime_id]['data'])
+            && !empty($ret[$mime_id])
+            && isset($ret[$mime_id]['data'])
+            && !is_null($ret[$mime_id]['data'])
             && !strlen($ret[$mime_id]['data'])
             && !isset($ret[$mime_id]['status'])) {
             $ret[$mime_id] = null;

--- a/lib/Contents/Message.php
+++ b/lib/Contents/Message.php
@@ -647,7 +647,7 @@ class IMP_Contents_Message
                         }
                     }
 
-                    $part_text .= '<div class="mimePartData">' . $info['data'] . '</div>';
+                    $part_text .= '<div class="mimePartData">' . ($info['data'] ?? '') . '</div>';
                 } elseif ($show_parts == 'atc') {
                     $atc_parts[$id] = 1;
                 }

--- a/lib/Mime/Viewer/Status.php
+++ b/lib/Mime/Viewer/Status.php
@@ -182,12 +182,14 @@ class IMP_Mime_Viewer_Status extends Horde_Mime_Viewer_Base
             }
         }
 
-        $ret[$mime_id] = array_filter([
+        $ret[$mime_id] = [
             'data' => '',
-            'status' => $status ?: null,
             'type' => 'text/html; charset=' . $this->getConfigParam('charset'),
             'wrap' => 'mimePartWrap',
-        ]);
+        ];
+        if ($status) {
+            $ret[$mime_id]['status'] = $status;
+        }
 
         return $ret;
     }


### PR DESCRIPTION
## Summary
- Fix PHP 8 warning when rendering delivery status (`multipart/report`) messages inline
- `IMP_Mime_Viewer_Status` no longer drops the intentional empty `data` field via `array_filter()`
- Add defensive handling in `IMP_Contents` and `IMP_Contents_Message` when `data` is absent

## Motivation
Viewing certain delivery status reports logged:

```
PHP ERROR: Undefined array key "data" (Contents.php:679, Contents/Message.php:650)
```

`IMP_Mime_Viewer_Status` built its render result with `array_filter()`, which removed `'data' => ''` because empty strings are falsy. Downstream inline rendering then accessed a missing `data` key, especially when no recognized `Action` header produced status output.

## Changes
- **lib/Mime/Viewer/Status.php**: Build the render array explicitly; only include `status` when set
- **lib/Contents.php**: Guard the empty-part suppression check with `isset($ret[$mime_id]['data'])`
- **lib/Contents/Message.php**: Default missing `data` to an empty string when building part HTML

## Test plan
- [ ] Open a delivery status / bounce message (`multipart/report` with `message/delivery-status`) inline in IMP
- [ ] Confirm no `Undefined array key "data"` warnings in `/tmp-horde/horde.log`
- [ ] Confirm delivery status messages with recognized `Action` headers still show status UI
- [ ] Confirm ordinary text/HTML message rendering is unchanged
