### PR TITLE
fix(message): use locale-aware time formatting in IMP_Message_Date (#22)

### DIFF
--- a/lib/Message/Date.php
+++ b/lib/Message/Date.php
@@ -196,7 +196,9 @@ class IMP_Message_Date
      */
     private function _format($type, $udate)
     {
+        if (in_array($type, ['time_format', 'time_format_mini'], true)) {
+            return ltrim(Horde\Date\Format::formatDate((int) $udate, $GLOBALS['prefs']->getValue($type), $GLOBALS['language'] ?? 'en_US', Horde\Date\Format::TIME_ONLY));
+        }
         return ltrim(Horde\Date\Format::formatDate((int) $udate, $GLOBALS['prefs']->getValue($type), $GLOBALS['language'] ?? 'en_US'));
     }
-
 }


### PR DESCRIPTION
**Title:** `fix(message): use locale-aware time formatting in IMP_Message_Date (#22)`

**Description:**

`IMP_Message_Date::_format()` passed the preference value directly to `Horde\Date\Format::formatDate()`. When `time_format` or `time_format_mini` held a named ICU style (`'medium'`, `'short'`), `formatDate()` formatted the date portion instead of the time portion, resulting in dates being displayed where times were expected.

Fix by using `Horde\Date\Format::TIME_ONLY` for time preferences:

```php
if (in_array($type, ['time_format', 'time_format_mini'], true)) {
    return ltrim(Horde\Date\Format::formatDate((int) $udate, $GLOBALS['prefs']->getValue($type), $GLOBALS['language'] ?? 'en_US', Horde\Date\Format::TIME_ONLY));
}
return ltrim(Horde\Date\Format::formatDate((int) $udate, $GLOBALS['prefs']->getValue($type), $GLOBALS['language'] ?? 'en_US'));
```

Depends on feat(format): add TIME_ONLY constant and parameter to formatDate() : https://github.com/horde/Date/pull/19. 
@ralflang FYI.