### PR TITLE
fix(dynamic): handle dynamically inserted time elements via MutationObserver (#22)

### DIFF
--- a/js/relative_time.js
+++ b/js/relative_time.js
@@ -214,12 +214,41 @@
         }
     }
 
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', sweep);
-    } else {
+
+    function init() {
         sweep();
+        setTimeout(tick, 60 * 1000);
+    
+        // Watch for future DOM insertions (AJAX message loading).
+        if (window.MutationObserver) {
+            var observer = new MutationObserver(function(mutations) {
+                for (var i = 0; i < mutations.length; i++) {
+                    var added = mutations[i].addedNodes;
+                    for (var j = 0; j < added.length; j++) {
+                        var node = added[j];
+                        if (node.nodeType !== 1) continue;
+                        // The node itself.
+                        if (node.matches && node.matches('time[is="time-ago"]')) {
+                            register(node);
+                        }
+                        // Its descendants.
+                        var children = node.querySelectorAll('time[is="time-ago"]');
+                        for (var k = 0; k < children.length; k++) {
+                            register(children[k]);
+                        }
+                    }
+                }
+            });
+            observer.observe(document.body || document.documentElement, {
+                childList: true,
+                subtree: true
+            });
+        }
     }
 
-    // Kick off the refresh loop.
-    setTimeout(tick, 60 * 1000);
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
 }());


### PR DESCRIPTION
**Title:** `fix(dynamic): handle dynamically inserted time elements via MutationObserver (#22)`

**Description:**

The patch f398f58 replaced `time-elements.js` with `relative_time.js` using `Intl.RelativeTimeFormat` for localization. However, it lost the `MutationObserver` that `time-elements.js` used to detect `<time is="time-ago">` elements inserted dynamically via AJAX.

As a result, the relative time labels were never rendered for messages loaded dynamically in the mailbox view, leaving the `<time>` element empty and producing output like:

```
Yesterday, 4:05:55 PM CEST ()
```

This issue may be browser and timing dependent — connectedCallback fires reliably in some environments but not others, particularly under Firefox or when elements are inserted after script execution. The MutationObserver approach is robust regardless of browser or insertion timing.

Fix by replacing the one-shot `DOMContentLoaded` + `sweep()` with an `init()` function that runs `sweep()` for pre-existing elements and installs a `MutationObserver` to catch future insertions.