### PR TITLE
fix(imp): prevent search and subscribe PHP warnings

### DIFF
--- a/lib/Mailbox.php
+++ b/lib/Mailbox.php
@@ -960,6 +960,10 @@ class IMP_Mailbox
                 $notify = $sub
                     ? sprintf(_('You were successfully subscribed to "%s" and all subfolders.'), $this->display)
                     : sprintf(_('You were successfully unsubscribed from "%s" and all subfolders.'), $this->display);
+            } else {
+                $notify = $sub
+                    ? sprintf(_('You were successfully subscribed to "%s".'), $this->display)
+                    : sprintf(_('You were successfully unsubscribed from "%s".'), $this->display);
             }
         }
 

--- a/lib/Search/Query.php
+++ b/lib/Search/Query.php
@@ -209,7 +209,16 @@ class IMP_Search_Query implements Serializable
                         }
                     }
 
-                    $this->_cache['mboxes'] = array_unique($out, SORT_REGULAR);
+                    $mboxes = [];
+                    foreach ($out as $mbox) {
+                        if (!$mbox instanceof IMP_Mailbox) {
+                            $mbox = IMP_Mailbox::get($mbox);
+                        }
+                        if ($mbox) {
+                            $mboxes[strval($mbox)] = $mbox;
+                        }
+                    }
+                    $this->_cache['mboxes'] = array_values($mboxes);
                 }
 
                 return $this->_cache['mboxes'];


### PR DESCRIPTION
## Summary
- Normalize `IMP_Search_Query` mailbox lists to `IMP_Mailbox` objects before deduplication
- Ensure `IMP_Mailbox::subscribe()` always sets a success notification when the parent mailbox action succeeded

## Motivation
`array_unique(..., SORT_REGULAR)` could keep mailbox path strings instead of `IMP_Mailbox` objects when the same mailbox appeared as both, causing `Attempt to read property "container" on string` in search query building. With `subfolders: true`, ignored subfolder subscribe errors left `$notify` undefined even though the parent mailbox subscribe/unsubscribe had already succeeded.

## Changes
- Build the cached `mboxes` list by normalizing through `IMP_Mailbox::get()` and deduplicating by mailbox name
- Fall back to the single-mailbox success message when no subfolder action succeeded

## Test plan
- [ ] Run a mailbox search spanning folders with subfolder expansion
- [ ] Subscribe/unsubscribe a mailbox with the subfolders option when some subfolders fail on the server
