### PR TITLE
fix(dynamic): make search_refresh actually refresh virtual folders

### DIFF
--- a/lib/Ajax/Application.php
+++ b/lib/Ajax/Application.php
@@ -269,7 +269,9 @@ class IMP_Ajax_Application extends Horde_Core_Ajax_Application
      *
      * Variables used:
      *   - cacheid: (string) The browser (ViewPort) cache identifier.
-     *   - forceUpdate: (integer) If 1, forces an update.
+     *   - forceUpdate: (integer) If 1, forces an update. Accepted at
+     *                  either the top level (as sent by IMP.poll()) or
+     *                  nested under 'viewport' as 'force'.
      *
      * @param boolean $rw  Open mailbox as READ+WRITE?
      *
@@ -278,8 +280,13 @@ class IMP_Ajax_Application extends Horde_Core_Ajax_Application
      */
     public function changed($rw = null)
     {
-        /* Forced viewport return. */
-        if ($this->_vars->viewport->force) {
+        /* Forced viewport return. Accept both the nested viewport->force
+         * flag and the top-level forceUpdate flag: the dynamic view sends
+         * forceUpdate=1 from IMP.poll(true) (e.g. the search_refresh
+         * toolbar button) and IMP_Ajax_Application_Handler_Common::viewPort()
+         * sets vars->forceUpdate after a sort change to re-run search
+         * mailboxes. */
+        if ($this->_vars->viewport->force || $this->_vars->forceUpdate) {
             return true;
         }
 

--- a/lib/Ajax/Application/Handler/Common.php
+++ b/lib/Ajax/Application/Handler/Common.php
@@ -38,7 +38,24 @@ class IMP_Ajax_Application_Handler_Common extends Horde_Core_Ajax_Application_Ha
          * separate poll action because there are other tasks done when
          * specifically requesting a poll. */
 
-        $this->_base->queue->quota($this->_base->indices->mailbox, false);
+        $mailbox = $this->_base->indices->mailbox;
+
+        /* If the user forced a poll on a search mailbox (e.g. clicked the
+         * search_refresh toolbar button on the Virtual INBOX), the search
+         * cacheid alone will not advance because it is derived from the
+         * query generation counter which is only bumped by mutations.
+         * Invalidate the underlying query and rebuild its mailbox list so
+         * changed() can see fresh state and the viewport gets repopulated. */
+        if (($this->vars->forceUpdate || $this->vars->viewport->force) &&
+            $mailbox->search) {
+            $imp_search = $GLOBALS['injector']->getInstance('IMP_Search');
+            if (isset($imp_search[strval($mailbox)])) {
+                $imp_search[strval($mailbox)]->invalidateCache();
+                $mailbox->list_ob->rebuild(true);
+            }
+        }
+
+        $this->_base->queue->quota($mailbox, false);
 
         if ($this->_base->changed()) {
             $this->_base->addTask('viewport', $this->_base->viewPortData(true));


### PR DESCRIPTION
## Summary

Fixes #86.

Clicking the `search_refresh` icon on the Virtual INBOX (or any virtual folder / search mailbox) animated the spinner briefly but left the message list unchanged.

Two contributing issues, both server-side:

1. `IMP.poll(true)` in `js/base.js` sends `forceUpdate=1` at the top level of the Ajax parameters, but `IMP_Ajax_Application::changed()` only inspected `viewport->force`. The force flag was silently dropped for every caller that used it, including the `viewPort()` handler's own sort-preference-change branch on line 84.

2. Even with force honored, a search mailbox's cacheid is derived from `IMP_Search_Query::cacheGeneration()`, which only advances when `invalidateCache()` is called — and nothing on the read-only poll path invalidated it. Deletions worked because `IMP_Indices::delete()` already calls `IMP_Search::invalidateMailboxes()`.

**Changes:**

- `lib/Ajax/Application.php` — `changed()` now accepts `forceUpdate` at the top level in addition to the pre-existing `viewport->force` path. Strictly additive.
- `lib/Ajax/Application/Handler/Common.php` — `poll()` gains a guarded pre-step: when a force flag is set **and** the current mailbox is a search mailbox, invalidate the underlying query's cache and rebuild its mailbox list so `changed()` sees fresh state and the viewport gets repopulated. Real IMAP folders take exactly the same path they did before.

No JS wire-format change. No PHP signature changes.