### PR TITLE
feat(imp): add ensureImapConnection for stateless IMAP login

### DIFF
--- a/lib/Api.php
+++ b/lib/Api.php
@@ -382,6 +382,27 @@ class IMP_Api extends Horde_Registry_Api
     }
 
     /**
+     * Ensure a live IMAP connection exists for the current user.
+     *
+     * Stateless entry points (ActiveSync, RPC) authenticate to Horde but
+     * still require an explicit IMAP login for hordeauth backends. Exposed
+     * as a 'mail' API method so Horde_Core can trigger the login without
+     * depending on IMP directly.
+     *
+     * @param array $credentials  Optional fallback credentials (userId,
+     *                            password, server). See
+     *                            IMP_Auth::ensureImapConnection().
+     *
+     * @throws Horde_Auth_Exception
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     */
+    public function ensureImapConnection(array $credentials = [])
+    {
+        IMP_Auth::ensureImapConnection($credentials);
+    }
+
+    /**
      * Return the list of user-settable IMAP flags.
      *
      * @param string $mailbox  If set, returns the list of flags filtered by

--- a/lib/Auth.php
+++ b/lib/Auth.php
@@ -90,6 +90,83 @@ class IMP_Auth
     }
 
     /**
+     * Ensure a live IMAP connection exists.
+     *
+     * Unlike authenticate(), this always opens the mail server connection when
+     * needed. Stateless entry points (ActiveSync, RPC) authenticate to Horde
+     * first but still require an explicit IMAP login for hordeauth backends.
+     *
+     * @param array $credentials  Optional fallback credentials:
+     *   - userId: (string) Username.
+     *   - password: (string) Password.
+     *   - server: (string) Server key from backends.php.
+     *
+     * @throws Horde_Auth_Exception
+     *
+     * @author Torben Dannhauer <torben@dannhauer.de>
+     */
+    public static function ensureImapConnection(array $credentials = [])
+    {
+        global $injector, $registry;
+
+        $imp_imap = $injector->getInstance('IMP_Factory_Imap')->create();
+        if ($imp_imap->init) {
+            return;
+        }
+
+        if (!isset($credentials['server'])) {
+            $credentials['server'] = self::getAutoLoginServer();
+        }
+        if (empty($credentials['server'])) {
+            throw new Horde_Auth_Exception('', Horde_Auth::REASON_MESSAGE);
+        }
+
+        $servers = IMP_Imap::loadServerConfig();
+        $serverConfig = $servers[$credentials['server']] ?? null;
+
+        if ((empty($credentials['userId']) || !isset($credentials['password']))
+            && $registry->getAuth()
+            && $serverConfig
+            && !empty($serverConfig->hordeauth)) {
+            $hordeauth = $serverConfig->hordeauth;
+            $credentials['userId'] = $registry->getAuth(
+                strcasecmp($hordeauth, 'full') === 0 ? null : 'bare'
+            );
+            $stored = $registry->getAuthCredential('password');
+            if ($stored !== false) {
+                $credentials['password'] = $stored;
+            }
+        }
+
+        if (empty($credentials['userId'])
+            || !isset($credentials['password'])
+            || !strlen((string) $credentials['password'])) {
+            throw new Horde_Auth_Exception('', Horde_Auth::REASON_BADLOGIN);
+        }
+
+        try {
+            $credentials = $injector->getInstance('Horde_Core_Hooks')->callHook(
+                'imap_preauthenticate',
+                'imp',
+                [$credentials]
+            );
+        } catch (Horde_Exception_HookNotSet $e) {
+        }
+
+        try {
+            $imp_imap->createBaseImapObject(
+                $credentials['userId'],
+                $credentials['password'],
+                $credentials['server']
+            );
+            $imp_imap->login();
+        } catch (IMP_Imap_Exception $e) {
+            self::_log(false, $imp_imap);
+            throw $e->authException();
+        }
+    }
+
+    /**
      * Perform transparent authentication.
      *
      * @param Horde_Auth_Application $auth_ob  The authentication object.

--- a/lib/Auth.php
+++ b/lib/Auth.php
@@ -154,7 +154,8 @@ class IMP_Auth
 
         if (empty($credentials['userId'])
             || !isset($credentials['password'])
-            || !strlen((string) $credentials['password'])) {
+            || (!is_string($credentials['password']) && !($credentials['password'] instanceof Horde_Imap_Client_Password_Xoauth2))
+            || (is_string($credentials['password']) && $credentials['password'] === '')) {
             throw new Horde_Auth_Exception('', Horde_Auth::REASON_BADLOGIN);
         }
 

--- a/lib/Auth.php
+++ b/lib/Auth.php
@@ -118,12 +118,20 @@ class IMP_Auth
             $credentials['server'] = self::getAutoLoginServer();
         }
         if (empty($credentials['server'])) {
-            throw new Horde_Auth_Exception('', Horde_Auth::REASON_MESSAGE);
+            throw new Horde_Auth_Exception(
+                _('No IMAP backend is available for auto-login.'),
+                Horde_Auth::REASON_MESSAGE
+            );
         }
 
         $servers = IMP_Imap::loadServerConfig();
+        if ($servers === false) {
+            throw new Horde_Auth_Exception(
+                _('Could not load IMAP backend configuration.'),
+                Horde_Auth::REASON_MESSAGE
+            );
+        }
         $serverConfig = $servers[$credentials['server']] ?? null;
-
         if ((empty($credentials['userId']) || !isset($credentials['password']))
             && $registry->getAuth()
             && $serverConfig

--- a/lib/Auth.php
+++ b/lib/Auth.php
@@ -111,6 +111,12 @@ class IMP_Auth
 
         $imp_imap = $injector->getInstance('IMP_Factory_Imap')->create();
         if ($imp_imap->init) {
+            try {
+                $imp_imap->login();
+            } catch (IMP_Imap_Exception $e) {
+                self::_log(false, $imp_imap);
+                throw $e->authException();
+            }
             return;
         }
 


### PR DESCRIPTION
## Summary
- Add `IMP_Auth::ensureImapConnection()` to open the IMAP connection on demand.
- Expose it via the `mail` API as `IMP_Api::ensureImapConnection()`.

## Motivation
Stateless entry points (ActiveSync, RPC) authenticate to Horde but do not always establish an IMAP login. With `hordeauth` backends this leaves `imapOb()` returning `null`, breaking mail features that assume a live client. `IMP_Auth::authenticate()` is tied to the interactive login flow and returns early when a client already exists, so it is not a reliable way to force a connection from these entry points.

## Changes
- `IMP_Auth::ensureImapConnection(array $credentials = [])`: no-op if already initialised; otherwise resolves the auto-login server, fills hordeauth credentials from the session (honoring `full`/`bare`), runs the `imap_preauthenticate` hook, then creates the base IMAP object and logs in.
- `IMP_Api::ensureImapConnection()`: thin `mail` API wrapper delegating to `IMP_Auth`, so `Horde_Core` can call `$registry->mail->ensureImapConnection()` without a hard dependency on IMP.

## Test plan
- [ ] hordeauth backend: from a context without an established IMAP session, call `$registry->mail->ensureImapConnection()` and confirm `imapOb()` then returns a live client.
- [ ] Already-connected session: confirm no-op.
- [ ] Missing/invalid credentials: confirm `Horde_Auth_Exception`.
