### PR TITLE
fix(imp): return IMP_Mailbox objects from Vtrash mboxes

### DIFF
--- a/lib/Search/Vfolder/Vtrash.php
+++ b/lib/Search/Vfolder/Vtrash.php
@@ -64,7 +64,9 @@ class IMP_Search_Vfolder_Vtrash extends IMP_Search_Vfolder_Builtin
                     $iterator::NONIMAP,
                 ]);
 
-                return array_map('strval', iterator_to_array($iterator, false));
+                return IMP_Mailbox::get(
+                    array_map('strval', iterator_to_array($iterator, false))
+                );
         }
 
         return parent::__get($name);


### PR DESCRIPTION
## Summary
- Fix `IMP_Search_Vfolder_Vtrash::mboxes` to return `IMP_Mailbox` objects instead of raw strings.

## Motivation
Virtual Trash is queried/polled frequently, producing repeated PHP 8 warnings:
`Attempt to read property "container" on string` at `lib/Search/Query.php:270`.
The base `IMP_Search_Query` getters (`query`, `querytext`) expect `IMP_Mailbox`
objects, and `IMP_Search_Vfolder_Vinbox` already returns them.

## Changes
- Wrap the iterator result in `IMP_Mailbox::get(...)` in `Vtrash::__get('mboxes')`.

## Test plan
- [ ] Open/poll Virtual Trash; confirm the warning no longer appears in the Horde log.
- [ ] Expunge from Virtual Trash still works (relies on `IMP_Mailbox` objects in the process list).
