### PR TITLE
fix(auth): declare 'loginparams' capability so the server selector works regardless of auth driver

### DIFF
--- a/lib/Application.php
+++ b/lib/Application.php
@@ -53,9 +53,9 @@ class IMP_Application extends Horde_Registry_Application
         'add',
         'authenticate',
         'list',
+        'loginparams',
         'remove',
         'transparent',
-        'loginparams',
     ];
 
     /**

--- a/lib/Application.php
+++ b/lib/Application.php
@@ -55,6 +55,7 @@ class IMP_Application extends Horde_Registry_Application
         'list',
         'remove',
         'transparent',
+        'loginparams',
     ];
 
     /**


### PR DESCRIPTION
IMP_Application::authLoginParams() (which builds the server selector when $conf['server']['server_list'] = 'shown') was only reachable via Horde_Core_Auth_Application::getLoginParams() when the Horde auth driver was 'application' pointed at imp. Declaring 'loginparams' in $auth lets horde/base's LoginService/login.php resolve these params independently, via hasCapability('loginparams').