### PR TITLE
fix(imp): refresh search list after trash delete

### DIFF
--- a/js/base.js
+++ b/js/base.js
@@ -3802,7 +3802,14 @@ var ImpBase = {
         opts.vs = this._getSelection(opts);
 
         if (this._doMsgAction('deleteMessages', opts, {})) {
-            this.updateFlag(opts.vs, ImpCore.conf.FLAG_DELETED, true);
+            /* When using a Trash mailbox (nodeleteshow), messages are moved
+             * or hidden — they must not be painted as IMAP \Deleted. That
+             * optimistic mark is only correct for classic mark-for-deletion
+             * mode, and in search views it often sticks even after a successful
+             * move-to-trash. Rely on the server disappear/viewport refresh. */
+            if (!this.viewport.getMetaData('nodeleteshow')) {
+                this.updateFlag(opts.vs, ImpCore.conf.FLAG_DELETED, true);
+            }
         }
     },
 

--- a/lib/Ajax/Application.php
+++ b/lib/Ajax/Application.php
@@ -419,6 +419,14 @@ class IMP_Ajax_Application extends Horde_Core_Ajax_Application
             $changed = ($this->indices->mailbox->getSort()->sortby == Horde_Imap_Client::SORT_THREAD);
         }
 
+        /* Search BUIDs are session-synthetic and the result set is rebuilt
+         * after mailbox mutations. Always refresh the viewport so moved/
+         * deleted messages leave the search list instead of lingering with
+         * an optimistic \Deleted appearance. */
+        if (!$changed && $this->indices->mailbox->search) {
+            $changed = true;
+        }
+
         if ($changed) {
             $this->addTask('viewport', $this->viewPortData(true));
         } elseif (($indices instanceof IMP_Indices_Mailbox)

--- a/lib/Indices.php
+++ b/lib/Indices.php
@@ -444,46 +444,49 @@ class IMP_Indices implements ArrayAccess, Countable, Iterator
             $imp_imap = $ob->mbox->imp_imap;
             $ids_ob = $imp_imap->getIdsOb($ob->uids);
             $processed = false;
+            $moved_to_trash = false;
 
             /* Trash is only valid for IMAP mailboxes. */
             if ($use_trash_mbox
                 && ($ob->mbox != $trash)
                 /* TODO(?): Don't use Trash mailbox for remote accounts. */
-                && !$ob->mbox->remote_mbox) {
-                if ($ob->mbox->access_expunge) {
-                    try {
-                        if ($mark_seen) {
-                            $imp_imap->store($ob->mbox, [
-                                'add' => [Horde_Imap_Client::FLAG_SEEN],
-                                'ids' => $ids_ob,
-                            ]);
-                        }
-
-                        $imp_imap->copy($ob->mbox, $trash, [
+                && !$ob->mbox->remote_mbox
+                && $ob->mbox->access_expunge) {
+                try {
+                    if ($mark_seen) {
+                        $imp_imap->store($ob->mbox, [
+                            'add' => [Horde_Imap_Client::FLAG_SEEN],
                             'ids' => $ids_ob,
-                            'move' => true,
                         ]);
-                        $affected_mailboxes[strval($ob->mbox)] = $ob->mbox;
-                        $affected_mailboxes[strval($trash)] = $trash;
-                        $processed = true;
-                    } catch (IMP_Imap_Exception $e) {
-                        if ($e->getCode() == $e::OVERQUOTA) {
-                            $notification->push(
-                                _('You are over your quota, so your messages will be permanently deleted instead of moved to the Trash mailbox.'),
-                                'horde.warning'
-                            );
-
-                            $idx = new IMP_Indices($ob->mbox, $ob->uids);
-                            return $idx->delete([
-                                'keeplog' => !empty($opts['keeplog']),
-                                'nuke' => true,
-                            ]);
-                        }
-
-                        return false;
                     }
+
+                    $imp_imap->copy($ob->mbox, $trash, [
+                        'ids' => $ids_ob,
+                        'move' => true,
+                    ]);
+                    $affected_mailboxes[strval($ob->mbox)] = $ob->mbox;
+                    $affected_mailboxes[strval($trash)] = $trash;
+                    $processed = true;
+                    $moved_to_trash = true;
+                } catch (IMP_Imap_Exception $e) {
+                    if ($e->getCode() == $e::OVERQUOTA) {
+                        $notification->push(
+                            _('You are over your quota, so your messages will be permanently deleted instead of moved to the Trash mailbox.'),
+                            'horde.warning'
+                        );
+
+                        $idx = new IMP_Indices($ob->mbox, $ob->uids);
+                        return $idx->delete([
+                            'keeplog' => !empty($opts['keeplog']),
+                            'nuke' => true,
+                        ]);
+                    }
+
+                    return false;
                 }
-            } else {
+            }
+
+            if (!$moved_to_trash) {
                 /* Delete message logs now. This may result in loss of message
                  * log data for messages that might not be deleted - i.e. if
                  * an error occurs. But 1) the user has already indicated they


### PR DESCRIPTION
## Summary
- Fix search-result delete so messages are moved to Trash (or leave the list) instead of sticking with an optimistic IMAP `\Deleted` mark when `use_trash` is enabled.
- Always refresh the search viewport after delete so synthetic BUIDs and rebuilt result sets stay in sync.
- If move-to-trash cannot run because the mailbox lacks expunge rights, fall back to mark-as-deleted instead of doing nothing.

## Motivation
Deleting multiple messages from IMP search results painted them as deleted but left them in place, while the same action from a normal mailbox correctly honored the Trash preference.

## Changes
- `js/base.js`: skip optimistic `\Deleted` when viewport metadata `nodeleteshow` is set (Trash mode).
- `lib/Ajax/Application.php`: force a full viewport refresh after delete in search mailboxes.
- `lib/Indices.php`: treat failed move-to-trash (no expunge ACL) as mark-as-deleted rather than a silent no-op.

## Test plan
- [ ] Enable move-to-Trash in IMP prefs (real Trash folder).
- [ ] Search for messages, multi-select results, click Delete.
- [ ] Confirm messages leave the search list and appear in Trash.
- [ ] Confirm delete from a normal mailbox still moves to Trash.
- [ ] Hard-refresh the browser so updated `js/base.js` is loaded.
