### PR TITLE
feat(imp): add "block remote images only" mode to image replacement preference

### DIFF
--- a/config/prefs.php
+++ b/config/prefs.php
@@ -1013,12 +1013,17 @@ $_prefs['alternative_display'] = [
     },
 ];
 
-$_prefs['image_replacement'] = [
-    'value' => 1,
-    'type' => 'checkbox',
-    'desc' => _("Block images in messages unless they are specifically requested to be loaded?"),
+$_prefs['image_replacement'] = array(
+    'value' => 2,
+    'type'  => 'enum',
+    'enum'  => array(
+        0 => _("Show all images"),
+        1 => _("Block all images in messages unless they are specifically requested to be loaded?"),
+        2 => _("Show inline images, block remote images"),
+    ),
+    'desc'  => _("How should images in HTML messages be handled?"),
     'help' => 'prefs-image_replacement',
-];
+);
 
 $_prefs['image_replacement_manage'] = [
     'type' => 'special',

--- a/lib/Mime/Viewer/Html.php
+++ b/lib/Mime/Viewer/Html.php
@@ -146,6 +146,7 @@ class IMP_Mime_Viewer_Html extends Horde_Mime_Viewer_Html
                 'imgblock' => false,
                 'imgbroken' => false,
                 'inline' => $inline,
+                'remoteblock' => false,
                 'style' => [],
             ];
         }
@@ -231,8 +232,13 @@ class IMP_Mime_Viewer_Html extends Horde_Mime_Viewer_Html
 
                     $link = $text = null;
                     if ($this->_imptmp['imgblock']) {
-                        $text = _('Images have been blocked in this message part.');
-                        $link = _('Show Images?');
+                        if ($this->_imptmp['remoteblock']) {
+                            $text = _('Remote images have been blocked in this message part.');
+                            $link = _('Load Remote Images?');
+                        } else {
+                            $text = _('Images have been blocked in this message part.');
+                            $link = _('Show Images?');
+                        }
                     } elseif ($this->_imptmp['cssblock']) {
                         $text = _('Message styling has been suppressed in this message part since the style data lives on a remote server.');
                         $link = _('Load Styling?');
@@ -372,6 +378,7 @@ class IMP_Mime_Viewer_Html extends Horde_Mime_Viewer_Html
                     $val = $node->getAttribute('src');
 
                     /* Multipart/related. */
+                    $is_cid = false;
                     if (($tag == 'img') && ($id = $this->_cidSearch($val))) {
                         $val = $this->getConfigParam('imp_contents')->urlView(null, 'view_attach', ['params' => [
                             'ctype' => 'image/*',
@@ -381,7 +388,7 @@ class IMP_Mime_Viewer_Html extends Horde_Mime_Viewer_Html
                     }
 
                     /* Block images.*/
-                    if ($this->_imgBlock()) {
+                    if ($this->_imgBlock() && !($is_cid && $this->_isRemoteBlock())) {
                         if (Horde_Url_Data::isData($val)) {
                             $url = new Horde_Url_Data($val);
                         } else {
@@ -401,6 +408,9 @@ class IMP_Mime_Viewer_Html extends Horde_Mime_Viewer_Html
                             $node->setAttribute(self::IMGBLOCK, $url);
                             $node->setAttribute('src', $this->_imgBlockImg());
                             $this->_imptmp['imgblock'] = true;
+                            if ($this->_isRemoteBlock()) {
+                                $this->_imptmp['remoteblock'] = true;
+                            }
                         } else {
                             $node->parentNode->removeChild($node);
                             $this->_imptmp['imgbroken'] = true;
@@ -636,6 +646,9 @@ class IMP_Mime_Viewer_Html extends Horde_Mime_Viewer_Html
         } else {
             $this->_imptmp['node']->setAttribute(self::IMGBLOCK, $matches[2]);
             $this->_imptmp['imgblock'] = true;
+            if ($this->_isRemoteBlock()) {
+                $this->_imptmp['remoteblock'] = true;
+            }
             $replace = $this->_imgBlockImg();
         }
         return $matches[1] . $replace . $matches[3];
@@ -700,4 +713,15 @@ class IMP_Mime_Viewer_Html extends Horde_Mime_Viewer_Html
         return $this->_imptmp['blockimg'];
     }
 
+    /**
+     * Are we in "block remote images only" mode?
+     *
+     * @return boolean  True if only remote images are blocked.
+     */
+    protected function _isRemoteBlock()
+    {
+        global $prefs;
+
+        return ($prefs->getValue('image_replacement') == 2);
+    }
 }

--- a/locale/en/help.xml
+++ b/locale/en/help.xml
@@ -571,7 +571,10 @@
     <entry id="prefs-image_replacement">
         <title>Message: Preferences: Image Replacement</title>
         <para>
-            For messages displayed inline (i.e. on the message view page), should all image tags be blocked until you specifically decide to view those images? Note that, if explicitly viewing the attachment, images will always be displayed.
+            For messages displayed inline (i.e. on the message view page), controls how images embedded in HTML messages are handled: show all images (including remote ones, which may be used by senders to track whether you have read a message); show only images attached directly to the message while blocking those loaded from remote servers (recommended); or block all images until you specifically decide to view them.
+        </para>
+        <para>
+            In all blocking modes, a notification appears allowing you to unblock images on a per-message basis, or to permanently allow images from a given sender. Note that, if explicitly viewing the attachment, images will always be displayed.
         </para>
     </entry>
 


### PR DESCRIPTION
Add a third option to the image_replacement preference (value 2) that
shows inline (cid:) images while blocking remote ones. Update the HTML
MIME viewer to skip blocking for already-resolved cid: images in this
mode, display a distinct notification for remote image blocking, and
update the English help text accordingly.

The existing binary block/show preference dates from an era where
blocking all images served both performance and privacy goals. Today,
inline (cid:) images are integral parts of the message content while
remote images are the actual privacy concern, as they allow senders to
confirm delivery and read time. This new mode reflects that distinction
and is set as the new default to align IMP with the behaviour of modern
mail clients.