### PR TITLE
Fix/ngettext plural

### DIFF
--- a/lib/Mime/Viewer/Audio.php
+++ b/lib/Mime/Viewer/Audio.php
@@ -58,14 +58,14 @@ class IMP_Mime_Viewer_Audio extends Horde_Mime_Viewer_Audio
 
         if ($minutes = floor($duration->value / 60)) {
             $text[] = sprintf(
-                ngettext(_('%d minute'), _('%d minutes'), $minutes),
+                ngettext('%d minute', '%d minutes', $minutes),
                 $minutes
             );
         }
 
         if ($seconds = ($duration->value % 60)) {
             $text[] = sprintf(
-                ngettext(_('%d second'), _('%d seconds'), $seconds),
+                ngettext('%d second', '%d seconds', $seconds),
                 $seconds
             );
         }

--- a/lib/Mime/Viewer/Video.php
+++ b/lib/Mime/Viewer/Video.php
@@ -80,14 +80,14 @@ class IMP_Mime_Viewer_Video extends Horde_Mime_Viewer_Default
 
             if ($minutes = floor($duration->value / 60)) {
                 $text[] = sprintf(
-                    ngettext(_('%d minute'), _('%d minutes'), $minutes),
+                    ngettext('%d minute', '%d minutes', $minutes),
                     $minutes
                 );
             }
 
             if ($seconds = ($duration->value % 60)) {
                 $text[] = sprintf(
-                    ngettext(_('%d second'), _('%d seconds'), $seconds),
+                    ngettext('%d second', '%d seconds', $seconds),
                     $seconds
                 );
             }

--- a/locale/imp.pot
+++ b/locale/imp.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR Horde LLC (http://www.horde.org/)
-# This file is distributed under the same license as the IMP package.
+# This file is distributed under the same license as the imp package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: IMP\n"
+"Project-Id-Version: imp\n"
 "Report-Msgid-Bugs-To: dev@lists.horde.org\n"
-"POT-Creation-Date: 2025-07-09 09:51+0200\n"
+"POT-Creation-Date: 2026-08-17 20:46+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -64,7 +64,7 @@ msgstr[1] ""
 msgid "%d Messages"
 msgstr ""
 
-#: lib/Ajax/Imple/VcardImport.php:104
+#: lib/Ajax/Imple/VcardImport.php:106
 #, php-format
 msgid "%d contact was successfully added to your address book."
 msgid_plural "%d contacts were successfully added to your address book."
@@ -78,7 +78,7 @@ msgid_plural "%d messages were purged from \"%s\"."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/Dynamic/Mailbox.php:543 lib/Smartmobile.php:179
+#: lib/Dynamic/Mailbox.php:542 lib/Smartmobile.php:181
 #, php-format
 msgid "%d messages"
 msgstr ""
@@ -101,12 +101,9 @@ msgstr ""
 #: lib/Mime/Viewer/Audio.php:61 lib/Mime/Viewer/Video.php:83
 #, php-format
 msgid "%d minute"
-msgstr ""
-
-#: lib/Mime/Viewer/Audio.php:61 lib/Mime/Viewer/Video.php:83
-#, php-format
-msgid "%d minutes"
-msgstr ""
+msgid_plural "%d minutes"
+msgstr[0] ""
+msgstr[1] ""
 
 #: lib/Block/Newmail.php:104
 #, php-format
@@ -130,24 +127,21 @@ msgstr ""
 #: lib/Mime/Viewer/Audio.php:68 lib/Mime/Viewer/Video.php:90
 #, php-format
 msgid "%d second"
-msgstr ""
-
-#: lib/Mime/Viewer/Audio.php:68 lib/Mime/Viewer/Video.php:90
-#, php-format
-msgid "%d seconds"
-msgstr ""
+msgid_plural "%d seconds"
+msgstr[0] ""
+msgstr[1] ""
 
 #: lib/Search/Element/Header.php:58
 #, php-format
 msgid "%s (Header) for \"%s\""
 msgstr ""
 
-#: lib/Contents.php:790 lib/IMP.php:79 src/Imp.php:81
+#: lib/Contents.php:792 lib/IMP.php:79 src/Imp.php:81
 #, php-format
 msgid "%s KB"
 msgstr ""
 
-#: lib/Contents.php:789 lib/IMP.php:78 src/Imp.php:80
+#: lib/Contents.php:791 lib/IMP.php:78 src/Imp.php:80
 #, php-format
 msgid "%s MB"
 msgstr ""
@@ -162,19 +156,29 @@ msgstr ""
 msgid "%s for '%s'"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:401
+#: lib/Mime/Viewer/Itip.php:469
 #, php-format
 msgid "%s has cancelled \"%s\"."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:395
+#: lib/Mime/Viewer/Itip.php:463
 #, php-format
 msgid "%s has cancelled an instance of the recurring \"%s\"."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:390
+#: lib/Mime/Viewer/Itip.php:458
 #, php-format
 msgid "%s has cancelled multiple instances of the recurring \"%s\"."
+msgstr ""
+
+#: lib/Mime/Viewer/Itip.php:436
+#, php-format
+msgid "%s has declined your proposed new time for \"%s\"."
+msgstr ""
+
+#: lib/Mime/Viewer/Itip.php:410
+#, php-format
+msgid "%s has proposed a new time for \"%s\"."
 msgstr ""
 
 #: lib/Mime/Viewer/Itip.php:210
@@ -182,12 +186,12 @@ msgstr ""
 msgid "%s has replied to a free/busy request."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:754
+#: lib/Mime/Viewer/Itip.php:822
 #, php-format
 msgid "%s has replied to the assignment of task \"%s\"."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:363
+#: lib/Mime/Viewer/Itip.php:391
 #, php-format
 msgid "%s has replied to the invitation to \"%s\"."
 msgstr ""
@@ -197,7 +201,7 @@ msgstr ""
 msgid "%s has sent you free/busy information."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:544
+#: lib/Dynamic/Mailbox.php:543
 #, php-format
 msgid "%s is: %s."
 msgstr ""
@@ -212,17 +216,17 @@ msgstr ""
 msgid "%s requests your free/busy information."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:329
+#: lib/Mime/Viewer/Itip.php:330
 #, php-format
 msgid "%s requests your presence at \"%s\"."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:557
+#: lib/Dynamic/Mailbox.php:556
 #, php-format
 msgid "%s selected."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:316
+#: lib/Mime/Viewer/Itip.php:317
 #, php-format
 msgid "%s wants to notify you about changes in \"%s\"."
 msgstr ""
@@ -237,33 +241,33 @@ msgstr ""
 msgid "%s was successfully added to your address book."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:351
+#: lib/Mime/Viewer/Itip.php:379
 #, php-format
 msgid "%s wishes to amend \"%s\"."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:745
+#: lib/Mime/Viewer/Itip.php:813
 #, php-format
 msgid "%s wishes to assign you \"%s\"."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:305 lib/Mime/Viewer/Itip.php:319
-#: lib/Mime/Viewer/Itip.php:738
+#: lib/Mime/Viewer/Itip.php:306 lib/Mime/Viewer/Itip.php:320
+#: lib/Mime/Viewer/Itip.php:806
 #, php-format
 msgid "%s wishes to make you aware of \"%s\"."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:358
+#: lib/Mime/Viewer/Itip.php:386
 #, php-format
 msgid "%s wishes to receive the latest information about \"%s\"."
 msgstr ""
 
-#: lib/Compose.php:2735
+#: lib/Compose.php:2746
 #, php-format
 msgid "%u Forwarded Messages"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:542 lib/Smartmobile.php:178
+#: lib/Dynamic/Mailbox.php:541 lib/Smartmobile.php:180
 msgid "1 message"
 msgstr ""
 
@@ -277,39 +281,43 @@ msgid ""
 "recipient."
 msgstr ""
 
-#: lib/Compose.php:3552
+#: lib/Compose.php:3591
 msgid ""
 "A message you were composing when your session expired has been recovered. "
 "You may resume composing your message by going to your Drafts mailbox."
 msgstr ""
 
-#: lib/Prefs/Special/Acl.php:173
+#: lib/Prefs/Special/Acl.php:171
 #, php-format
 msgid "ACL for \"%s\" successfully created for the mailbox \"%s\"."
 msgstr ""
 
-#: lib/Prefs/Special/Acl.php:198
+#: lib/Prefs/Special/Acl.php:196
 #, php-format
 msgid "ACL rights for \"%s\" updated for the mailbox \"%s\"."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:747
+#: lib/Mime/Viewer/Itip.php:815
 msgid "Accept and add this to my tasklist"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:340
+#: lib/Mime/Viewer/Itip.php:368
 msgid "Accept and add to my calendar"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:337
+#: lib/Mime/Viewer/Itip.php:365
 msgid "Accept and update in my calendar"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:344
+#: lib/Mime/Viewer/Itip.php:428
+msgid "Accept proposed time"
+msgstr ""
+
+#: lib/Mime/Viewer/Itip.php:372
 msgid "Accept request"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:828
+#: lib/Mime/Viewer/Itip.php:893
 msgid "Accepted"
 msgstr ""
 
@@ -321,12 +329,12 @@ msgstr ""
 msgid "Accesskey Esc"
 msgstr ""
 
-#: lib/Prefs/Special/Remote.php:148
+#: lib/Prefs/Special/Remote.php:146
 #, php-format
 msgid "Account \"%s\" added."
 msgstr ""
 
-#: lib/Prefs/Special/Remote.php:160
+#: lib/Prefs/Special/Remote.php:158
 #, php-format
 msgid "Account \"%s\" deleted."
 msgstr ""
@@ -346,7 +354,7 @@ msgid "Add Account"
 msgstr ""
 
 #: templates/dynamic/compose.html.php:158
-#: templates/smartmobile/compose.html.php:86
+#: templates/smartmobile/compose.html.php:88
 msgid "Add Attachment"
 msgstr ""
 
@@ -362,7 +370,7 @@ msgstr ""
 msgid "Add OR clause"
 msgstr ""
 
-#: config/prefs.php:1397
+#: config/prefs.php:1410
 msgid "Add a \"Printed By\" header to the top of printed messages?"
 msgstr ""
 
@@ -378,19 +386,19 @@ msgstr ""
 msgid "Add these addresses by clicking OK"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:307
+#: lib/Mime/Viewer/Itip.php:308
 msgid "Add this to my calendar"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:740 lib/Mime/Viewer/Itip.php:748
+#: lib/Mime/Viewer/Itip.php:808 lib/Mime/Viewer/Itip.php:816
 msgid "Add this to my tasklist"
 msgstr ""
 
-#: lib/Dynamic/Base.php:156
+#: lib/Dynamic/Base.php:158
 msgid "Add to Address Book"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:341
+#: lib/Mime/Viewer/Itip.php:369
 msgid "Add to my calendar"
 msgstr ""
 
@@ -404,7 +412,7 @@ msgstr ""
 msgid "Added flag \"%s\"."
 msgstr ""
 
-#: config/prefs.php:1088
+#: config/prefs.php:1101
 msgid ""
 "Additional headers to display when viewing: <em>(enter each header on a new "
 "line)</em>"
@@ -414,21 +422,21 @@ msgstr ""
 msgid "Address Book"
 msgstr ""
 
-#: config/prefs.php:885
+#: config/prefs.php:892
 msgid "Address Books"
 msgstr ""
 
-#: lib/Compose.php:2604
+#: lib/Compose.php:2605
 msgid "Address rejected by the sending mail server."
 msgstr ""
 
-#: config/prefs.php:50
+#: config/prefs.php:54
 msgid ""
 "Addresses to BCC all messages: <em>(optional, enter each address on a new "
 "line)</em>"
 msgstr ""
 
-#: config/prefs.php:43
+#: config/prefs.php:47
 msgid ""
 "Addresses to explicitly tie to this identity: <em>(optional, enter each "
 "address on a new line)</em>"
@@ -438,11 +446,11 @@ msgstr ""
 msgid "Administer"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:500
+#: lib/Dynamic/Mailbox.php:499
 msgid "Advanced Search..."
 msgstr ""
 
-#: lib/Search/Element/Daterange.php:101
+#: lib/Search/Element/Daterange.php:102
 #, php-format
 msgid "After '%s'"
 msgstr ""
@@ -451,11 +459,11 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: lib/Search/Query.php:283 templates/search/search-all.html.php:2
+#: lib/Search/Query.php:299 templates/search/search-all.html.php:2
 msgid "All Mailboxes"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:470
+#: lib/Dynamic/Mailbox.php:469
 msgid "All Parts"
 msgstr ""
 
@@ -470,7 +478,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/Dynamic/Mailbox.php:534
+#: lib/Dynamic/Mailbox.php:533
 msgid ""
 "All messages in this mailbox will be downloaded into the format that you "
 "choose. Depending on the size of the mailbox, this action may take awhile."
@@ -493,16 +501,16 @@ msgstr ""
 msgid "All old sent-mail mailboxes more than %s months old will be deleted."
 msgstr ""
 
-#: lib/Prefs/Special/Acl.php:208
+#: lib/Prefs/Special/Acl.php:206
 #, php-format
 msgid "All rights on mailbox \"%s\" successfully removed for \"%s\"."
 msgstr ""
 
-#: config/prefs.php:990
+#: config/prefs.php:998
 msgid "Allow attachments to be stripped from messages?"
 msgstr ""
 
-#: config/prefs.php:287
+#: config/prefs.php:294
 msgid "Allow filter rules to be applied in any mailbox?"
 msgstr ""
 
@@ -522,7 +530,7 @@ msgstr ""
 msgid "Allow viewing of message source?"
 msgstr ""
 
-#: config/prefs.php:1097
+#: config/prefs.php:1110
 msgid "Always prompt"
 msgstr ""
 
@@ -531,7 +539,7 @@ msgstr ""
 msgid "Always showing images in messages sent by %s."
 msgstr ""
 
-#: lib/Indices.php:648
+#: lib/Indices.php:677
 msgid "An error occured while attempting to strip the part."
 msgstr ""
 
@@ -543,7 +551,7 @@ msgstr ""
 msgid "An unknown error occured while creating the new task."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:725
+#: lib/Mime/Viewer/Itip.php:793
 msgid "An unknown person"
 msgstr ""
 
@@ -555,23 +563,23 @@ msgstr ""
 msgid "Append"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:489
+#: lib/Dynamic/Mailbox.php:488
 msgid "Apply Filters"
 msgstr ""
 
-#: config/prefs.php:267
+#: config/prefs.php:274
 msgid "Apply filter rules upon logging on?"
 msgstr ""
 
-#: config/prefs.php:277
+#: config/prefs.php:284
 msgid "Apply filter rules whenever Inbox is displayed?"
 msgstr ""
 
-#: lib/Prefs/Special/Remote.php:47
+#: lib/Prefs/Special/Remote.php:45
 msgid "Are you sure you want to delete this account?"
 msgstr ""
 
-#: lib/Prefs/Special/Searches.php:110
+#: lib/Prefs/Special/Searches.php:108
 msgid "Are you sure you want to delete this filter?"
 msgstr ""
 
@@ -579,22 +587,22 @@ msgstr ""
 msgid "Are you sure you want to delete this flag?"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPublicKey.php:79
-#: lib/Prefs/Special/SmimePublicKey.php:77
+#: lib/Prefs/Special/PgpPublicKey.php:77
+#: lib/Prefs/Special/SmimePublicKey.php:75
 msgid "Are you sure you want to delete this public key?"
 msgstr ""
 
-#: lib/Prefs/Special/Searches.php:111
+#: lib/Prefs/Special/Searches.php:109
 msgid "Are you sure you want to delete this virtual folder?"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:80
-#: lib/Prefs/Special/SmimePrivateKey.php:150
+#: lib/Prefs/Special/PgpPrivateKey.php:78
+#: lib/Prefs/Special/SmimePrivateKey.php:151
 msgid ""
 "Are you sure you want to delete your keypair? (This is NOT recommended!)"
 msgstr ""
 
-#: lib/Dynamic/Base.php:195
+#: lib/Dynamic/Base.php:197
 msgid "Are you sure you wish to PERMANENTLY delete this attachment?"
 msgstr ""
 
@@ -606,27 +614,27 @@ msgstr ""
 msgid "Are you sure you wish to report this message as spam?"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:237
+#: lib/Dynamic/Mailbox.php:236
 msgid "Arrival Time"
 msgstr ""
 
-#: config/prefs.php:1491
+#: config/prefs.php:1504
 msgid "Arrival time on server"
 msgstr ""
 
-#: lib/Dynamic/Base.php:172
+#: lib/Dynamic/Base.php:174
 msgid "As Attachment"
 msgstr ""
 
-#: config/prefs.php:741
+#: config/prefs.php:748
 msgid "As attachment"
 msgstr ""
 
-#: config/prefs.php:743
+#: config/prefs.php:750
 msgid "As both body text and an attachment"
 msgstr ""
 
-#: config/prefs.php:1471
+#: config/prefs.php:1484
 msgid "Ascending"
 msgstr ""
 
@@ -642,47 +650,47 @@ msgstr ""
 msgid "Attach contact information"
 msgstr ""
 
-#: lib/Compose.php:3483
+#: lib/Compose.php:3522
 #, php-format
 msgid ""
 "Attached file \"%s\" exceeds the attachment size limits. File NOT attached."
 msgstr ""
 
-#: lib/Compose.php:3483
+#: lib/Compose.php:3522
 msgid "Attached file exceeds the attachment size limits. File NOT attached."
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:402
+#: lib/Ajax/Imple/ItipRequest.php:487
 msgid "Attached is a reply to a calendar request you sent."
 msgstr ""
 
-#: attachment.php:53
+#: attachment.php:54
 #, php-format
 msgid "Attachment %s deleted."
 msgstr ""
 
-#: lib/Dynamic/Base.php:174
+#: lib/Dynamic/Base.php:176
 msgid "Attachment and Body Text"
 msgstr ""
 
-#: attachment.php:55
+#: attachment.php:56
 msgid "Attachment doesn't exist."
 msgstr ""
 
-#: lib/Compose.php:1258
+#: lib/Compose.php:1259
 msgid "Attachment stripped: Original attachment type"
 msgstr ""
 
-#: lib/Ajax/Application/Handler/Dynamic.php:939 lib/Dynamic/Message.php:58
+#: lib/Ajax/Application/Handler/Dynamic.php:939 lib/Dynamic/Message.php:57
 msgid "Attachment successfully stripped."
 msgstr ""
 
-#: lib/Compose.php:3071 lib/Compose.php:3078
-#: templates/smartmobile/compose.html.php:79
+#: lib/Compose.php:3106 lib/Compose.php:3113
+#: templates/smartmobile/compose.html.php:81
 msgid "Attachments"
 msgstr ""
 
-#: templates/smartmobile/compose.html.php:70
+#: templates/smartmobile/compose.html.php:72
 msgid "Attachments..."
 msgstr ""
 
@@ -690,7 +698,7 @@ msgstr ""
 msgid "Attendees"
 msgstr ""
 
-#: lib/Contents.php:1290
+#: lib/Contents.php:1297
 msgid "Audio"
 msgstr ""
 
@@ -710,7 +718,7 @@ msgstr ""
 msgid "Automatically Generated Messages"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:907
+#: lib/Mime/Viewer/Itip.php:972
 msgid "Awaiting Response"
 msgstr ""
 
@@ -722,44 +730,45 @@ msgstr ""
 msgid "Backends"
 msgstr ""
 
-#: lib/Basic/Contacts.php:102 lib/Basic/Search.php:72 lib/Contents/View.php:228
+#: lib/Basic/Contacts.php:102 lib/Basic/Search.php:72 lib/Contents/View.php:234
 #: templates/contacts/contacts.html.php:37
 #: templates/dynamic/compose.html.php:130
 #: templates/dynamic/mailbox.html.php:154 templates/dynamic/message.html.php:96
 msgid "Bcc"
 msgstr ""
 
-#: lib/Search/Element/Daterange.php:108
+#: lib/Search/Element/Daterange.php:109
 #, php-format
 msgid "Before '%s'"
 msgstr ""
 
-#: lib/Search/Element/Daterange.php:121
+#: lib/Search/Element/Daterange.php:122
 #, php-format
 msgid "Between '%s' and '%s'"
 msgstr ""
 
-#: lib/Mime/Viewer/Html.php:184
+#: lib/Mime/Viewer/Html.php:185
 msgid ""
 "Beware of following any links in it or of providing the sender with any "
 "personal information."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:327 lib/Dynamic/Mailbox.php:434
+#: lib/Dynamic/Mailbox.php:326 lib/Dynamic/Mailbox.php:433
 msgid "Blacklist"
 msgstr ""
 
-#: config/prefs.php:1011
+#: config/prefs.php:1021
 msgid ""
-"Block images in messages unless they are specifically requested to be loaded?"
+"Block all images in messages unless they are specifically requested to be "
+"loaded?"
 msgstr ""
 
-#: lib/Basic/Search.php:84 lib/Dynamic/Mailbox.php:495
+#: lib/Basic/Search.php:84 lib/Dynamic/Mailbox.php:494
 #: templates/smartmobile/search.html.php:10
 msgid "Body"
 msgstr ""
 
-#: config/prefs.php:549
+#: config/prefs.php:556
 msgid "Bottom"
 msgstr ""
 
@@ -776,7 +785,7 @@ msgstr ""
 msgid "Bulk Messages"
 msgstr ""
 
-#: lib/Compose.php:1906
+#: lib/Compose.php:1907
 #, php-format
 msgid "Can't attach contact information: %s"
 msgstr ""
@@ -784,7 +793,7 @@ msgstr ""
 #: templates/contacts/contacts.html.php:58 templates/pgp/import_key.html.php:43
 #: templates/prefs/remote.html.php:80 templates/saveimage/saveimage.html.php:20
 #: templates/search/search.html.php:102
-#: templates/smartmobile/compose.html.php:54
+#: templates/smartmobile/compose.html.php:56
 #: templates/smartmobile/copymove.html.php:20
 #: templates/smartmobile/message.html.php:91
 #: templates/smartmobile/message.html.php:106
@@ -817,39 +826,39 @@ msgid ""
 "certificates."
 msgstr ""
 
-#: lib/Indices.php:377
+#: lib/Indices.php:389
 msgid "Cannot move messages to Trash - no Trash mailbox set in preferences."
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:73
+#: lib/Ajax/Imple/ItipRequest.php:76
 msgid "Cannot retrieve calendar data from message."
 msgstr ""
 
-#: lib/Ajax/Imple/ImportEncryptKey.php:70
+#: lib/Ajax/Imple/ImportEncryptKey.php:72
 msgid "Cannot retrieve public key from message."
 msgstr ""
 
-#: lib/Ajax/Imple/VcardImport.php:72
+#: lib/Ajax/Imple/VcardImport.php:74
 msgid "Cannot retrieve vCard data from message."
 msgstr ""
 
-#: lib/Indices.php:541
+#: lib/Indices.php:570
 msgid "Cannot strip the part as the mailbox is read-only."
 msgstr ""
 
-#: lib/Basic/Contacts.php:101 lib/Basic/Search.php:68 lib/Compose.php:2779
-#: lib/Contents/View.php:224 lib/Smartmobile.php:173
+#: lib/Basic/Contacts.php:101 lib/Basic/Search.php:68 lib/Compose.php:2790
+#: lib/Contents/View.php:230 lib/Smartmobile.php:175
 #: templates/contacts/contacts.html.php:36
 #: templates/dynamic/compose.html.php:122
 #: templates/dynamic/mailbox.html.php:150 templates/dynamic/message.html.php:92
 msgid "Cc"
 msgstr ""
 
-#: templates/smartmobile/compose.html.php:36
+#: templates/smartmobile/compose.html.php:38
 msgid "Cc:"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:889
+#: lib/Mime/Viewer/Itip.php:954
 msgid "Chair Person"
 msgstr ""
 
@@ -857,16 +866,16 @@ msgstr ""
 msgid "Change"
 msgstr ""
 
-#: config/prefs.php:1413
+#: config/prefs.php:1426
 msgid ""
 "Change display preferences for viewing the listing of messages in a mailbox."
 msgstr ""
 
-#: config/prefs.php:1514
+#: config/prefs.php:1527
 msgid "Change folder navigation display preferences."
 msgstr ""
 
-#: config/prefs.php:16
+#: config/prefs.php:20
 msgid ""
 "Change the name, address, and signature that people see when they read and "
 "reply to your email."
@@ -876,11 +885,11 @@ msgstr ""
 msgid "Check Spelling"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:364
+#: lib/Dynamic/Mailbox.php:363
 msgid "Check for New Mail"
 msgstr ""
 
-#: config/prefs.php:369
+#: config/prefs.php:376
 msgid "Check for valid recipient PGP public keys while replying?"
 msgstr ""
 
@@ -888,15 +897,15 @@ msgstr ""
 msgid "Check mailbox for new mail?"
 msgstr ""
 
-#: config/prefs.php:504
+#: config/prefs.php:511
 msgid "Check spelling before sending a message?"
 msgstr ""
 
-#: lib/Dynamic/Compose/Common.php:290 lib/Dynamic/Mailbox.php:529
+#: lib/Dynamic/Compose/Common.php:290 lib/Dynamic/Mailbox.php:528
 msgid "Checking..."
 msgstr ""
 
-#: config/prefs.php:951
+#: config/prefs.php:958
 msgid "Choose the address book to use when adding addresses."
 msgstr ""
 
@@ -904,7 +913,7 @@ msgstr ""
 msgid "Clear Search"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:445
+#: lib/Dynamic/Mailbox.php:444
 msgid "Clear Sort"
 msgstr ""
 
@@ -930,7 +939,7 @@ msgid ""
 "view."
 msgstr ""
 
-#: lib/Mime/Viewer/Tgz.php:80 lib/Mime/Viewer/Zip.php:90
+#: lib/Mime/Viewer/Tgz.php:80 lib/Mime/Viewer/Zip.php:93
 msgid "Click to display the file contents."
 msgstr ""
 
@@ -964,7 +973,7 @@ msgstr ""
 msgid "Click to verify the message."
 msgstr ""
 
-#: lib/Mime/Viewer/Html.php:253
+#: lib/Mime/Viewer/Html.php:259
 msgid ""
 "Click to view HTML data in new window; it is possible this will allow you to "
 "view the message correctly."
@@ -974,16 +983,16 @@ msgstr ""
 msgid "Click to view the message in a new window."
 msgstr ""
 
-#: templates/smartmobile/compose.html.php:90
+#: templates/smartmobile/compose.html.php:92
 msgid "Close"
 msgstr ""
 
-#: config/prefs.php:787
+#: config/prefs.php:794
 msgid "Close the compose window after saving a draft?"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:234 lib/Dynamic/Mailbox.php:296
-#: lib/Dynamic/Mailbox.php:373
+#: lib/Dynamic/Mailbox.php:233 lib/Dynamic/Mailbox.php:295
+#: lib/Dynamic/Mailbox.php:372
 msgid "Collapse All"
 msgstr ""
 
@@ -995,30 +1004,30 @@ msgstr ""
 msgid "Color"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:53 lib/Prefs/Special/Flag.php:65
+#: lib/Dynamic/Mailbox.php:52 lib/Prefs/Special/Flag.php:65
 msgid "Color Picker"
 msgstr ""
 
-#: config/prefs.php:1549
+#: config/prefs.php:1562
 msgid "Combine all namespaces"
 msgstr ""
 
-#: lib/Pgp.php:808 templates/itip/action.html.php:47
+#: lib/Pgp.php:847 templates/itip/action.html.php:47
 #: templates/prefs/pgpprivatekey.html.php:65
 msgid "Comment"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:840
+#: lib/Mime/Viewer/Itip.php:905
 msgid "Completed"
 msgstr ""
 
-#: config/prefs.php:484 config/prefs.php:624 config/prefs.php:670
-#: config/prefs.php:727 config/prefs.php:761 config/prefs.php:815
-#: config/prefs.php:884
+#: config/prefs.php:491 config/prefs.php:631 config/prefs.php:677
+#: config/prefs.php:734 config/prefs.php:768 config/prefs.php:822
+#: config/prefs.php:891
 msgid "Compose"
 msgstr ""
 
-#: config/prefs.php:625
+#: config/prefs.php:632
 msgid "Compose Templates"
 msgstr ""
 
@@ -1030,51 +1039,51 @@ msgstr ""
 msgid "Compose action completed. You may now safely close this window."
 msgstr ""
 
-#: config/prefs.php:485
+#: config/prefs.php:492
 msgid "Composition"
 msgstr ""
 
-#: config/prefs.php:318
+#: config/prefs.php:325
 msgid "Configure PGP encryption support."
 msgstr ""
 
-#: config/prefs.php:401
+#: config/prefs.php:408
 msgid "Configure S/MIME encryption support."
 msgstr ""
 
-#: config/prefs.php:1355
+#: config/prefs.php:1368
 msgid "Configure flag highlighting."
 msgstr ""
 
-#: config/prefs.php:301
+#: config/prefs.php:308
 msgid "Configure how event or meeting requests should be handled."
 msgstr ""
 
-#: config/prefs.php:971
+#: config/prefs.php:979
 msgid "Configure how messages are displayed."
 msgstr ""
 
-#: config/prefs.php:729
+#: config/prefs.php:736
 msgid "Configure how you forward mail."
 msgstr ""
 
-#: config/prefs.php:672
+#: config/prefs.php:679
 msgid "Configure how you reply to mail."
 msgstr ""
 
-#: config/prefs.php:486
+#: config/prefs.php:493
 msgid "Configure how you send mail."
 msgstr ""
 
-#: config/prefs.php:1389
+#: config/prefs.php:1402
 msgid "Configure message printing."
 msgstr ""
 
-#: config/prefs.php:141
+#: config/prefs.php:145
 msgid "Configure remote mail accounts to display."
 msgstr ""
 
-#: config/prefs.php:1225
+#: config/prefs.php:1238
 msgid "Configure spam reporting."
 msgstr ""
 
@@ -1086,7 +1095,7 @@ msgstr ""
 msgid "Contents of compressed file:"
 msgstr ""
 
-#: config/prefs.php:1308
+#: config/prefs.php:1321
 msgid ""
 "Control when new mail will be checked for, and whether or not to notify you "
 "when it arrives."
@@ -1096,7 +1105,7 @@ msgstr ""
 msgid "Convert HTML data to plain text and view in new window."
 msgstr ""
 
-#: config/prefs.php:1068
+#: config/prefs.php:1081
 msgid "Convert textual emoticons into graphical ones?"
 msgstr ""
 
@@ -1104,12 +1113,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:530
+#: lib/Dynamic/Mailbox.php:529
 #, php-format
 msgid "Copy %s to %s"
 msgstr ""
 
-#: lib/Dynamic/Base.php:157
+#: lib/Dynamic/Base.php:159
 msgid "Copy to Clipboard"
 msgstr ""
 
@@ -1128,7 +1137,7 @@ msgstr ""
 msgid "Could not add rights for user \"%s\" for the mailbox \"%s\"."
 msgstr ""
 
-#: lib/Compose.php:3338
+#: lib/Compose.php:3373
 #, php-format
 msgid "Could not attach %s to the message."
 msgstr ""
@@ -1138,7 +1147,7 @@ msgstr ""
 msgid "Could not authenticate to %s."
 msgstr ""
 
-#: lib/Contents/View.php:149
+#: lib/Contents/View.php:157
 msgid "Could not auto-determine data type."
 msgstr ""
 
@@ -1147,7 +1156,7 @@ msgstr ""
 msgid "Could not delete Virtual Folder \"%s\"."
 msgstr ""
 
-#: lib/Mailbox.php:1381
+#: lib/Mailbox.php:1394
 #, php-format
 msgid "Could not delete messages from %s. This mailbox is read-only."
 msgstr ""
@@ -1160,12 +1169,16 @@ msgstr ""
 msgid "Could not find remote server configuration."
 msgstr ""
 
+#: lib/Auth.php:136
+msgid "Could not load IMAP backend configuration."
+msgstr ""
+
 #: lib/Basic/Listinfo.php:37 lib/Basic/Saveimage.php:44 lib/Basic/Thread.php:49
 #: lib/Dynamic/Maillog.php:61
 msgid "Could not load message."
 msgstr ""
 
-#: lib/Imap.php:902
+#: lib/Imap.php:924
 msgid ""
 "Could not move all messages between mailboxes, so the original mailbox was "
 "not removed."
@@ -1177,7 +1190,7 @@ msgid ""
 "preferences."
 msgstr ""
 
-#: lib/Ajax/Application/Handler/Common.php:699
+#: lib/Ajax/Application/Handler/Common.php:716
 msgid "Could not open mailbox."
 msgstr ""
 
@@ -1190,16 +1203,20 @@ msgstr ""
 msgid "Could not remove rights for user \"%s\" for the mailbox \"%s\"."
 msgstr ""
 
-#: lib/Compose.php:1974 lib/Compose.php:2359 lib/Dynamic/Compose.php:287
+#: lib/Compose.php:1975 lib/Compose.php:2360 lib/Dynamic/Compose.php:287
 msgid "Could not retrieve message data from the mail server."
 msgstr ""
 
-#: lib/Pgp.php:360
+#: lib/Pgp.php:399
 #, php-format
 msgid "Could not retrieve public key for %s."
 msgstr ""
 
-#: lib/Dynamic/Base.php:167 lib/Dynamic/Mailbox.php:329
+#: lib/Ajax/Imple/ItipRequest.php:149 lib/Mime/Viewer/Itip.php:420
+msgid "Counter proposal recorded."
+msgstr ""
+
+#: lib/Dynamic/Base.php:169 lib/Dynamic/Mailbox.php:328
 msgid "Create Filter"
 msgstr ""
 
@@ -1207,7 +1224,7 @@ msgstr ""
 msgid "Create Keys"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:255 lib/Dynamic/Mailbox.php:292
+#: lib/Dynamic/Mailbox.php:254 lib/Dynamic/Mailbox.php:291
 #: templates/flist/flist.html.php:11
 msgid "Create Mailbox"
 msgstr ""
@@ -1216,7 +1233,7 @@ msgstr ""
 msgid "Create New Flag..."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:274
+#: lib/Dynamic/Mailbox.php:273
 msgid "Create New Template"
 msgstr ""
 
@@ -1224,29 +1241,29 @@ msgstr ""
 msgid "Create Subfolders/Rename Mailbox"
 msgstr ""
 
-#: lib/Prefs/Special/Sentmail.php:48
+#: lib/Prefs/Special/Sentmail.php:46
 msgid "Create a new sent-mail mailbox"
 msgstr ""
 
-#: config/prefs.php:204
+#: config/prefs.php:208
 msgid ""
 "Create filtering rules to organize your incoming mail, sort it into "
 "mailboxes, and delete spam."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:531
+#: lib/Dynamic/Mailbox.php:530
 msgid "Create mailbox:"
 msgstr ""
 
-#: config/prefs.php:644
+#: config/prefs.php:651
 msgid "Create new Template"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:227 lib/Dynamic/Mailbox.php:357
+#: lib/Dynamic/Mailbox.php:226 lib/Dynamic/Mailbox.php:356
 msgid "Create subfolder"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:532
+#: lib/Dynamic/Mailbox.php:531
 #, php-format
 msgid "Create subfolder of %s:"
 msgstr ""
@@ -1255,15 +1272,15 @@ msgstr ""
 msgid "Create subfolders and rename mailbox"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:547
+#: lib/Dynamic/Mailbox.php:546
 msgid "Creating New Flag..."
 msgstr ""
 
-#: config/prefs.php:1494
+#: config/prefs.php:1507
 msgid "Criteria to use when sorting by date:"
 msgstr ""
 
-#: lib/Prefs/Special/Acl.php:76
+#: lib/Prefs/Special/Acl.php:74
 #, php-format
 msgid "Current access to %s"
 msgstr ""
@@ -1276,21 +1293,25 @@ msgstr ""
 msgid "Custom Header:"
 msgstr ""
 
+#: themes/dark/info.php:3
+msgid "Dark Mode"
+msgstr ""
+
 #: lib/Dynamic/Compose/Common.php:254
 msgid "Data"
 msgstr ""
 
-#: config/prefs.php:1457 lib/Basic/Search.php:92 lib/Compose.php:2759
-#: lib/Contents/View.php:221 lib/Dynamic/Mailbox.php:200
+#: config/prefs.php:1470 lib/Basic/Search.php:92 lib/Compose.php:2770
+#: lib/Contents/View.php:227 lib/Dynamic/Mailbox.php:199
 #: templates/dynamic/mailbox.html.php:138 templates/dynamic/message.html.php:75
 msgid "Date"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:263
+#: lib/Dynamic/Mailbox.php:262
 msgid "Date (Arrival)"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:264
+#: lib/Dynamic/Mailbox.php:263
 msgid "Date (Message)"
 msgstr ""
 
@@ -1302,7 +1323,7 @@ msgstr ""
 msgid "Date Selection"
 msgstr ""
 
-#: config/prefs.php:1492
+#: config/prefs.php:1505
 msgid "Date in message headers"
 msgstr ""
 
@@ -1310,28 +1331,40 @@ msgstr ""
 msgid "Days"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:831
+#: lib/Ajax/Imple/ItipRequest.php:597
+msgid "Decline Counter Proposal"
+msgstr ""
+
+#: lib/Ajax/Imple/ItipRequest.php:227
+msgid "Decline counter sent."
+msgstr ""
+
+#: lib/Mime/Viewer/Itip.php:431
+msgid "Decline proposed time"
+msgstr ""
+
+#: lib/Mime/Viewer/Itip.php:896
 msgid "Declined"
 msgstr ""
 
-#: config/prefs.php:521
+#: config/prefs.php:528
 msgid "Default method to compose messages:"
 msgstr ""
 
-#: config/prefs.php:1464
+#: config/prefs.php:1477
 msgid "Default sorting criteria:"
 msgstr ""
 
-#: config/prefs.php:1474
+#: config/prefs.php:1487
 msgid "Default sorting direction:"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:837
+#: lib/Mime/Viewer/Itip.php:902
 msgid "Delegated"
 msgstr ""
 
-#: lib/Dynamic/Compose/Common.php:177 lib/Dynamic/Mailbox.php:330
-#: lib/Dynamic/Mailbox.php:360 lib/Imap/Acl.php:197
+#: lib/Dynamic/Compose/Common.php:177 lib/Dynamic/Mailbox.php:329
+#: lib/Dynamic/Mailbox.php:359 lib/Imap/Acl.php:197
 #: templates/dynamic/mailbox.html.php:51 templates/dynamic/message.html.php:29
 #: templates/prefs/acl.html.php:44 templates/prefs/acl.html.php:79
 #: templates/prefs/pgppublickey.html.php:22
@@ -1342,8 +1375,8 @@ msgstr ""
 msgid "Delete"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPublicKey.php:79
-#: lib/Prefs/Special/SmimePublicKey.php:77
+#: lib/Prefs/Special/PgpPublicKey.php:77
+#: lib/Prefs/Special/SmimePublicKey.php:75
 #, php-format
 msgid "Delete %s Public Key"
 msgstr ""
@@ -1360,7 +1393,7 @@ msgstr ""
 msgid "Delete Secondary Personal Certificate"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:285
+#: lib/Dynamic/Mailbox.php:284
 msgid "Delete Virtual Folder"
 msgstr ""
 
@@ -1372,15 +1405,15 @@ msgstr ""
 msgid "Delete and rename mailbox"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:403
+#: lib/Mime/Viewer/Itip.php:471
 msgid "Delete from my calendar"
 msgstr ""
 
-#: config/prefs.php:571
+#: config/prefs.php:578
 msgid "Delete linked attachments after this many months (0 to never delete):"
 msgstr ""
 
-#: config/prefs.php:1256
+#: config/prefs.php:1269
 msgid "Delete message"
 msgstr ""
 
@@ -1388,12 +1421,12 @@ msgstr ""
 msgid "Delete messages"
 msgstr ""
 
-#: config/prefs.php:850
+#: config/prefs.php:857
 msgid ""
 "Delete old sent mail mailboxes after this many months (0 to never delete):"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:229
+#: lib/Dynamic/Mailbox.php:228
 msgid "Delete subfolders"
 msgstr ""
 
@@ -1420,23 +1453,23 @@ msgstr ""
 msgid "Deleted flag \"%s\"."
 msgstr ""
 
-#: config/prefs.php:1115
+#: config/prefs.php:1128
 msgid "Deleting and Moving Messages"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:346
+#: lib/Mime/Viewer/Itip.php:374
 msgid "Deny request"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:270
+#: lib/Mime/Viewer/Itip.php:271
 msgid "Deny request for free/busy information"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:749
+#: lib/Mime/Viewer/Itip.php:817
 msgid "Deny task assignment"
 msgstr ""
 
-#: config/prefs.php:1472
+#: config/prefs.php:1485
 msgid "Descending"
 msgstr ""
 
@@ -1444,7 +1477,7 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lib/Prefs/Special/SmimePrivateKey.php:106
+#: lib/Prefs/Special/SmimePrivateKey.php:107
 #: templates/prefs/pgpprivatekey.html.php:22
 #: templates/prefs/pgpprivatekey.html.php:36
 #: templates/prefs/pgppublickey.html.php:21
@@ -1452,12 +1485,12 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
-#: config/prefs.php:1062
+#: config/prefs.php:1075
 msgid "Dim signatures?"
 msgstr ""
 
 #: templates/dynamic/compose.html.php:46
-#: templates/smartmobile/compose.html.php:65
+#: templates/smartmobile/compose.html.php:67
 msgid "Discard Draft"
 msgstr ""
 
@@ -1467,7 +1500,7 @@ msgid ""
 "text)? This conversion cannot be reversed."
 msgstr ""
 
-#: config/prefs.php:1332
+#: config/prefs.php:1345
 msgid "Display notification when new mail arrives?"
 msgstr ""
 
@@ -1475,24 +1508,24 @@ msgstr ""
 msgid "Do NOT Match"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:365
+#: lib/Dynamic/Mailbox.php:364
 msgid "Do Not Check for New Mail"
 msgstr ""
 
-#: config/prefs.php:1077
+#: config/prefs.php:1090
 msgid "Do not show parts"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:484
+#: lib/Dynamic/Mailbox.php:483
 msgid "Don't Show"
 msgstr ""
 
-#: lib/Contents.php:839 lib/Mime/Viewer/Tgz.php:121 lib/Mime/Viewer/Zip.php:131
+#: lib/Contents.php:841 lib/Mime/Viewer/Tgz.php:121 lib/Mime/Viewer/Zip.php:134
 #: templates/mime/compressed.html.php:10
 msgid "Download"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:525 lib/Dynamic/Message.php:124
+#: lib/Dynamic/Mailbox.php:524 lib/Dynamic/Message.php:123
 #, php-format
 msgid "Download All (%s)"
 msgstr ""
@@ -1505,11 +1538,11 @@ msgstr ""
 msgid "Download into a MBOX file (ZIP compressed)"
 msgstr ""
 
-#: lib/Compose.php:3098
+#: lib/Compose.php:3133
 msgid "Download link"
 msgstr ""
 
-#: lib/Compose.php:3091
+#: lib/Compose.php:3126
 #, php-format
 msgid "Download link: %s"
 msgstr ""
@@ -1518,7 +1551,7 @@ msgstr ""
 msgid "Draft"
 msgstr ""
 
-#: config/prefs.php:762 lib/Mailbox.php:1702 lib/Mailbox.php:1801
+#: config/prefs.php:769 lib/Mailbox.php:1721 lib/Mailbox.php:1820
 msgid "Drafts"
 msgstr ""
 
@@ -1530,7 +1563,7 @@ msgstr ""
 msgid "Drop file(s) here to attach."
 msgstr ""
 
-#: lib/Pgp.php:809
+#: lib/Pgp.php:848
 msgid "E-Mail"
 msgstr ""
 
@@ -1542,7 +1575,7 @@ msgstr ""
 msgid "ERROR: Your message could not be delivered."
 msgstr ""
 
-#: lib/Mime/Viewer/Html.php:185
+#: lib/Mime/Viewer/Html.php:186
 msgid "EXAMPLE LINK"
 msgstr ""
 
@@ -1550,7 +1583,7 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:382
+#: lib/Dynamic/Mailbox.php:381
 msgid "Edit ACL"
 msgstr ""
 
@@ -1570,36 +1603,36 @@ msgstr ""
 msgid "Edit Search Query"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:273 lib/Dynamic/Mailbox.php:314
+#: lib/Dynamic/Mailbox.php:272 lib/Dynamic/Mailbox.php:313
 msgid "Edit Template"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:284 lib/Ftree.php:1075
+#: lib/Dynamic/Mailbox.php:283 lib/Ftree.php:1075
 #: templates/search/search.html.php:7
 msgid "Edit Virtual Folder"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:279
+#: lib/Dynamic/Mailbox.php:278
 msgid "Edit Virtual Folders"
 msgstr ""
 
-#: config/prefs.php:744 lib/Dynamic/Base.php:176
+#: config/prefs.php:751 lib/Dynamic/Base.php:178
 msgid "Edit as New"
 msgstr ""
 
-#: config/prefs.php:626
+#: config/prefs.php:633
 msgid "Edit compose templates."
 msgstr ""
 
-#: config/prefs.php:232
+#: config/prefs.php:237
 msgid "Edit your Blacklist"
 msgstr ""
 
-#: config/prefs.php:214
+#: config/prefs.php:218
 msgid "Edit your Filter Rules"
 msgstr ""
 
-#: config/prefs.php:250
+#: config/prefs.php:256
 msgid "Edit your Whitelist"
 msgstr ""
 
@@ -1607,24 +1640,24 @@ msgstr ""
 msgid "Editing group lists not currently supported."
 msgstr ""
 
-#: lib/Mailbox.php:1432
+#: lib/Mailbox.php:1445
 #, php-format
 msgid "Emptied all messages from %s."
 msgstr ""
 
-#: lib/Mailbox.php:1394
+#: lib/Mailbox.php:1407
 msgid "Emptied all messages from Virtual Trash Folder."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:359
+#: lib/Dynamic/Mailbox.php:358
 msgid "Empty"
 msgstr ""
 
-#: config/prefs.php:339
+#: config/prefs.php:346
 msgid "Enable PGP functionality?"
 msgstr ""
 
-#: config/prefs.php:423
+#: config/prefs.php:430
 msgid "Enable S/MIME functionality?"
 msgstr ""
 
@@ -1640,22 +1673,22 @@ msgstr ""
 msgid "End"
 msgstr ""
 
-#: lib/Compose.php:2454
+#: lib/Compose.php:2455
 msgid "End forwarded message"
 msgstr ""
 
-#: lib/Compose.php:2261
+#: lib/Compose.php:2262
 msgid "End message"
 msgstr ""
 
-#: lib/Compose.php:2261
+#: lib/Compose.php:2262
 #, php-format
 msgid "End message from %s"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:74
-#: lib/Prefs/Special/SmimePrivateKey.php:132
-#: lib/Prefs/Special/SmimePrivateKey.php:139
+#: lib/Prefs/Special/PgpPrivateKey.php:72
+#: lib/Prefs/Special/SmimePrivateKey.php:133
+#: lib/Prefs/Special/SmimePrivateKey.php:140
 msgid "Enter Passphrase"
 msgstr ""
 
@@ -1663,35 +1696,35 @@ msgstr ""
 msgid "Enter Search Term"
 msgstr ""
 
-#: lib/Prefs/Special/ComposeTemplates.php:44
+#: lib/Prefs/Special/ComposeTemplates.php:42
 msgid "Enter the name for your new compose templates mailbox."
 msgstr ""
 
-#: lib/Prefs/Special/Drafts.php:40
+#: lib/Prefs/Special/Drafts.php:38
 msgid "Enter the name for your new drafts mailbox."
 msgstr ""
 
-#: lib/Prefs/Special/Spam.php:40
+#: lib/Prefs/Special/Spam.php:38
 msgid "Enter the name for your new spam mailbox."
 msgstr ""
 
-#: lib/Prefs/Special/Trash.php:40
+#: lib/Prefs/Special/Trash.php:38
 msgid "Enter the name for your new trash mailbox."
 msgstr ""
 
-#: lib/Ajax/Imple/PassphraseDialog.php:62
+#: lib/Ajax/Imple/PassphraseDialog.php:64
 msgid "Enter the passphrase used to encrypt this message."
 msgstr ""
 
-#: lib/Ajax/Imple/PassphraseDialog.php:58
+#: lib/Ajax/Imple/PassphraseDialog.php:60
 msgid "Enter your personal PGP passphrase."
 msgstr ""
 
-#: lib/Ajax/Imple/PassphraseDialog.php:66
+#: lib/Ajax/Imple/PassphraseDialog.php:68
 msgid "Enter your personal S/MIME passphrase."
 msgstr ""
 
-#: lib/Basic/Search.php:88 lib/Dynamic/Mailbox.php:494
+#: lib/Basic/Search.php:88 lib/Dynamic/Mailbox.php:493
 #: templates/smartmobile/search.html.php:9
 msgid "Entire Message"
 msgstr ""
@@ -1700,16 +1733,16 @@ msgstr ""
 msgid "Entire Message (including Headers)"
 msgstr ""
 
-#: lib/Basic/Thread.php:64 lib/Compose.php:1595
+#: lib/Basic/Thread.php:64 lib/Compose.php:1596
 #, php-format
 msgid "Entry \"%s\" was successfully added to the address book"
 msgstr ""
 
-#: lib/Mime/Status.php:93
+#: lib/Mime/Status.php:93 view.php:74
 msgid "Error"
 msgstr ""
 
-#: lib/Contents.php:115
+#: lib/Contents.php:115 lib/Contents.php:1334
 msgid "Error displaying message: message does not exist on server."
 msgstr ""
 
@@ -1721,27 +1754,32 @@ msgstr ""
 msgid "Error loading message list."
 msgstr ""
 
-#: lib/Ajax/Imple/VcardImport.php:75
+#: lib/Ajax/Imple/VcardImport.php:77
 msgid "Error reading the contact data."
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:333 lib/Ajax/Imple/ItipRequest.php:446
+#: lib/Ajax/Imple/ItipRequest.php:231
+#, php-format
+msgid "Error sending decline counter: %s."
+msgstr ""
+
+#: lib/Ajax/Imple/ItipRequest.php:418 lib/Ajax/Imple/ItipRequest.php:531
 #, php-format
 msgid "Error sending reply: %s."
 msgstr ""
 
-#: lib/Mbox/Import.php:196
+#: lib/Mbox/Import.php:201
 #, php-format
 msgid ""
 "Error when importing messages; %u messages successfully imported before "
 "error."
 msgstr ""
 
-#: lib/Smartmobile.php:182
+#: lib/Smartmobile.php:184
 msgid "Error when loading the message."
 msgstr ""
 
-#: lib/Compose.php:2564
+#: lib/Compose.php:2565
 msgid "Error when redirecting message."
 msgstr ""
 
@@ -1751,31 +1789,31 @@ msgid ""
 "your browser."
 msgstr ""
 
-#: config/prefs.php:300
+#: config/prefs.php:307
 msgid "Event Requests"
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:116
+#: lib/Ajax/Imple/ItipRequest.php:119
 msgid "Event successfully deleted."
 msgstr ""
 
-#: config/prefs.php:1323
+#: config/prefs.php:1336
 msgid "Every 15 minutes"
 msgstr ""
 
-#: config/prefs.php:1320
+#: config/prefs.php:1333
 msgid "Every 30 seconds"
 msgstr ""
 
-#: config/prefs.php:805 config/prefs.php:1322
+#: config/prefs.php:812 config/prefs.php:1335
 msgid "Every 5 minutes"
 msgstr ""
 
-#: config/prefs.php:1324
+#: config/prefs.php:1337
 msgid "Every half hour"
 msgstr ""
 
-#: config/prefs.php:804 config/prefs.php:1321
+#: config/prefs.php:811 config/prefs.php:1334
 msgid "Every minute"
 msgstr ""
 
@@ -1783,12 +1821,12 @@ msgstr ""
 msgid "Exceptions"
 msgstr ""
 
-#: lib/Smartmobile.php:174
+#: lib/Smartmobile.php:176
 msgid "Exit Search"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:233 lib/Dynamic/Mailbox.php:295
-#: lib/Dynamic/Mailbox.php:372
+#: lib/Dynamic/Mailbox.php:232 lib/Dynamic/Mailbox.php:294
+#: lib/Dynamic/Mailbox.php:371
 msgid "Expand All"
 msgstr ""
 
@@ -1800,7 +1838,7 @@ msgstr ""
 msgid "Expand Headers"
 msgstr ""
 
-#: config/prefs.php:1538
+#: config/prefs.php:1551
 msgid "Expand the entire folder tree by default in the folders view?"
 msgstr ""
 
@@ -1808,11 +1846,11 @@ msgstr ""
 msgid "Expiration"
 msgstr ""
 
-#: lib/Pgp.php:806
+#: lib/Pgp.php:845
 msgid "Expiration Date"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:376
+#: lib/Dynamic/Mailbox.php:375
 msgid "Export"
 msgstr ""
 
@@ -1830,7 +1868,7 @@ msgstr ""
 msgid "Filter \"%s\" created succesfully."
 msgstr ""
 
-#: lib/Prefs/Special/Searches.php:134
+#: lib/Prefs/Special/Searches.php:132
 #, php-format
 msgid "Filter \"%s\" deleted."
 msgstr ""
@@ -1840,7 +1878,7 @@ msgstr ""
 msgid "Filter \"%s\" edited successfully."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:482
+#: lib/Dynamic/Mailbox.php:481
 msgid "Filter By"
 msgstr ""
 
@@ -1848,11 +1886,11 @@ msgstr ""
 msgid "Filter mailboxes..."
 msgstr ""
 
-#: config/prefs.php:984
+#: config/prefs.php:992
 msgid "Filter message content for unwanted text (e.g. profanity)?"
 msgstr ""
 
-#: config/prefs.php:203
+#: config/prefs.php:207
 msgid "Filters"
 msgstr ""
 
@@ -1865,23 +1903,23 @@ msgstr ""
 msgid "Find"
 msgstr ""
 
-#: config/prefs.php:1441
+#: config/prefs.php:1454
 msgid "First (oldest) Unseen Message"
 msgstr ""
 
-#: config/prefs.php:1443
+#: config/prefs.php:1456
 msgid "First Page"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:546
+#: lib/Dynamic/Mailbox.php:545
 msgid "Flag Name:"
 msgstr ""
 
-#: lib/Flags.php:184
+#: lib/Flags.php:202
 msgid "Flag name already exists."
 msgstr ""
 
-#: lib/Flags.php:178
+#: lib/Flags.php:196
 msgid "Flag name must not be empty."
 msgstr ""
 
@@ -1893,11 +1931,11 @@ msgstr ""
 msgid "Flagged for Followup"
 msgstr ""
 
-#: config/prefs.php:1354
+#: config/prefs.php:1367
 msgid "Flags"
 msgstr ""
 
-#: lib/Indices.php:737
+#: lib/Indices.php:766
 #, php-format
 msgid ""
 "Flags were not changed for at least one message in the mailbox \"%s\" "
@@ -1906,15 +1944,15 @@ msgid ""
 "precautionary to ensure you don't overwrite flag changes."
 msgstr ""
 
-#: lib/Mailbox.php:1775
+#: lib/Mailbox.php:1794
 msgid "Folder"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:97
+#: lib/Dynamic/Mailbox.php:96
 msgid "Folder Actions"
 msgstr ""
 
-#: config/prefs.php:1513
+#: config/prefs.php:1526
 msgid "Folder Display"
 msgstr ""
 
@@ -1922,18 +1960,18 @@ msgstr ""
 msgid "Folder Navigator"
 msgstr ""
 
-#: lib/Smartmobile.php:175 templates/smartmobile/folders.html.php:2
+#: lib/Smartmobile.php:177 templates/smartmobile/folders.html.php:2
 #: templates/smartmobile/mailbox.html.php:2
 msgid "Folders"
 msgstr ""
 
-#: config/prefs.php:1000
+#: config/prefs.php:1008
 msgid ""
 "For messages with alternative representations of a text part, which part "
 "should be displayed?"
 msgstr ""
 
-#: lib/Compose.php:2395 lib/Compose.php:2398 lib/Dynamic/Mailbox.php:318
+#: lib/Compose.php:2396 lib/Compose.php:2399 lib/Dynamic/Mailbox.php:317
 #: lib/Notification/Event/Status.php:28 templates/dynamic/mailbox.html.php:32
 #: templates/dynamic/message.html.php:15
 #: templates/smartmobile/message.html.php:52
@@ -1944,15 +1982,15 @@ msgstr ""
 msgid "Forwarded"
 msgstr ""
 
-#: lib/Compose.php:2720
+#: lib/Compose.php:2731
 msgid "Forwarded Message"
 msgstr ""
 
-#: lib/Compose.php:2452
+#: lib/Compose.php:2453
 msgid "Forwarded message"
 msgstr ""
 
-#: lib/Compose.php:2452
+#: lib/Compose.php:2453
 #, php-format
 msgid "Forwarded message from %s"
 msgstr ""
@@ -1961,11 +1999,11 @@ msgstr ""
 msgid "Forwarded message will be automatically added to your outgoing message."
 msgstr ""
 
-#: config/prefs.php:728
+#: config/prefs.php:735
 msgid "Forwards"
 msgstr ""
 
-#: lib/Compose.php:1717
+#: lib/Compose.php:1718
 #, php-format
 msgid ""
 "Found the word %s in the message text although there are no files attached "
@@ -1973,20 +2011,20 @@ msgid ""
 "performed again for this message.)"
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:438
+#: lib/Ajax/Imple/ItipRequest.php:523
 msgid "Free/Busy Request Response"
 msgstr ""
 
-#: lib/Basic/Search.php:56 lib/Compose.php:2763 lib/Contents/View.php:222
-#: lib/Dynamic/Mailbox.php:180 lib/Dynamic/Mailbox.php:259
-#: lib/Dynamic/Mailbox.php:496 lib/Smartmobile.php:176
+#: lib/Basic/Search.php:56 lib/Compose.php:2774 lib/Contents/View.php:228
+#: lib/Dynamic/Mailbox.php:179 lib/Dynamic/Mailbox.php:258
+#: lib/Dynamic/Mailbox.php:495 lib/Smartmobile.php:178
 #: templates/dynamic/compose.html.php:102
 #: templates/dynamic/mailbox.html.php:142 templates/dynamic/message.html.php:84
 #: templates/smartmobile/search.html.php:11 templates/thread/thread.html.php:21
 msgid "From"
 msgstr ""
 
-#: config/prefs.php:1458
+#: config/prefs.php:1471
 msgid "From Address"
 msgstr ""
 
@@ -1998,9 +2036,9 @@ msgstr ""
 msgid "Gallery"
 msgstr ""
 
-#: config/prefs.php:14 config/prefs.php:113 config/prefs.php:139
-#: config/prefs.php:166 config/prefs.php:202 config/prefs.php:299
-#: config/prefs.php:316 config/prefs.php:399
+#: config/prefs.php:18 config/prefs.php:117 config/prefs.php:143
+#: config/prefs.php:170 config/prefs.php:206 config/prefs.php:306
+#: config/prefs.php:323 config/prefs.php:406
 msgid "General"
 msgstr ""
 
@@ -2012,7 +2050,7 @@ msgstr ""
 msgid "Go to your Inbox..."
 msgstr ""
 
-#: lib/Compose.php:1825
+#: lib/Compose.php:1826
 msgid "HTML Message"
 msgstr ""
 
@@ -2020,27 +2058,27 @@ msgstr ""
 msgid "HTML composition"
 msgstr ""
 
-#: config/prefs.php:997
+#: config/prefs.php:1005
 msgid "HTML part"
 msgstr ""
 
-#: lib/Pgp.php:810
+#: lib/Pgp.php:849
 msgid "Hash-Algorithm"
 msgstr ""
 
-#: config/prefs.php:1053
+#: config/prefs.php:1066
 msgid "Hidden"
 msgstr ""
 
-#: config/prefs.php:1051
+#: config/prefs.php:1064
 msgid "Hidden in List Messages"
 msgstr ""
 
-#: config/prefs.php:1050
+#: config/prefs.php:1063
 msgid "Hidden in Thread View"
 msgstr ""
 
-#: config/prefs.php:1052
+#: config/prefs.php:1065
 msgid "Hidden in Thread View and List Messages"
 msgstr ""
 
@@ -2048,19 +2086,19 @@ msgstr ""
 msgid "Hide Addresses"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:442
+#: lib/Dynamic/Mailbox.php:441
 msgid "Hide Deleted"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:425
+#: lib/Dynamic/Mailbox.php:424
 msgid "Hide Preview"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:293
+#: lib/Dynamic/Mailbox.php:292
 msgid "Hide Unsubscribed"
 msgstr ""
 
-#: config/prefs.php:1185
+#: config/prefs.php:1198
 msgid "Hide deleted messages even if using the Trash mailbox?"
 msgstr ""
 
@@ -2072,25 +2110,29 @@ msgstr ""
 msgid "High Priority"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:427
+#: lib/Dynamic/Mailbox.php:426
 msgid "Horizontal Layout"
 msgstr ""
 
-#: config/prefs.php:1055
+#: config/prefs.php:1024
+msgid "How should images in HTML messages be handled?"
+msgstr ""
+
+#: config/prefs.php:1068
 msgid ""
 "How should large blocks of quoted text be shown by default? (Toggling the "
 "block will always be available)."
 msgstr ""
 
-#: config/prefs.php:746
+#: config/prefs.php:753
 msgid "How should messages be forwarded by default?"
 msgstr ""
 
-#: config/prefs.php:1552
+#: config/prefs.php:1565
 msgid "How should namespaces be displayed in the folder tree view?"
 msgstr ""
 
-#: config/prefs.php:709
+#: config/prefs.php:716
 msgid "How to attribute quoted lines in a reply?"
 msgstr ""
 
@@ -2114,7 +2156,7 @@ msgid ""
 "empty, the first certificate will be used for all purposes."
 msgstr ""
 
-#: lib/Contents.php:1293 templates/saveimage/saveimage.html.php:7
+#: lib/Contents.php:1300 templates/saveimage/saveimage.html.php:7
 msgid "Image"
 msgstr ""
 
@@ -2122,11 +2164,11 @@ msgstr ""
 msgid "Image Data"
 msgstr ""
 
-#: lib/Mime/Viewer/Html.php:234
+#: lib/Mime/Viewer/Html.php:239
 msgid "Images have been blocked in this message part."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:377 templates/pgp/import_key.html.php:42
+#: lib/Dynamic/Mailbox.php:376 templates/pgp/import_key.html.php:42
 #: templates/smime/import_personal_key.html.php:62
 #: templates/smime/import_public_key.html.php:28
 msgid "Import"
@@ -2166,51 +2208,51 @@ msgstr ""
 msgid "Import Public S/MIME Key"
 msgstr ""
 
-#: lib/Mbox/Import.php:62
+#: lib/Mbox/Import.php:66
 #, php-format
 msgid "Imported %d message from %s."
 msgid_plural "Imported %d messages from %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/Dynamic/Mailbox.php:537
+#: lib/Dynamic/Mailbox.php:536
 msgid "Importing (this may take some time)..."
 msgstr ""
 
-#: lib/Dynamic/Base.php:173
+#: lib/Dynamic/Base.php:175
 msgid "In Body Text"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:843
+#: lib/Mime/Viewer/Itip.php:908
 msgid "In Process"
 msgstr ""
 
-#: config/prefs.php:742
+#: config/prefs.php:749
 msgid "In the body text"
 msgstr ""
 
-#: lib/Mailbox.php:1738 lib/Mailbox.php:1742 lib/Mailbox.php:1789
-#: lib/Remote.php:108
+#: lib/Mailbox.php:1757 lib/Mailbox.php:1761 lib/Mailbox.php:1808
+#: lib/Remote.php:111
 msgid "Inbox"
 msgstr ""
 
-#: config/prefs.php:693
+#: config/prefs.php:700
 msgid "Include a brief summary of the original message's header in a reply?"
 msgstr ""
 
-#: config/prefs.php:832
+#: config/prefs.php:839
 msgid "Include attachments in messages saved to Sent Mail?"
 msgstr ""
 
-#: config/prefs.php:702
+#: config/prefs.php:709
 msgid "Include original message in a reply?"
 msgstr ""
 
-#: config/prefs.php:1404
+#: config/prefs.php:1417
 msgid "Include the \"Bcc\" header when printing a sent email?"
 msgstr ""
 
-#: config/prefs.php:1504
+#: config/prefs.php:1517
 msgid ""
 "Indicate whether a message has attachments or is signed or encrypted in the "
 "mailbox listing?"
@@ -2220,21 +2262,21 @@ msgstr ""
 msgid "Info"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPublicKey.php:78
-#: lib/Prefs/Special/SmimePublicKey.php:76
+#: lib/Prefs/Special/PgpPublicKey.php:76
+#: lib/Prefs/Special/SmimePublicKey.php:74
 #, php-format
 msgid "Information on %s Public Key"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:78
+#: lib/Prefs/Special/PgpPrivateKey.php:76
 msgid "Information on Personal Private Key"
 msgstr ""
 
-#: lib/Prefs/Special/SmimePrivateKey.php:103
+#: lib/Prefs/Special/SmimePrivateKey.php:104
 msgid "Information on Personal Public Certificate"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:56
+#: lib/Prefs/Special/PgpPrivateKey.php:54
 msgid "Information on Personal Public Key"
 msgstr ""
 
@@ -2257,29 +2299,29 @@ msgstr ""
 msgid "Insert messages"
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:449
+#: lib/Ajax/Imple/ItipRequest.php:534
 msgid "Invalid Action selected for this component."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:526 lib/Mailbox/Ui.php:90 lib/Smartmobile.php:184
+#: lib/Dynamic/Mailbox.php:525 lib/Mailbox/Ui.php:90 lib/Smartmobile.php:186
 msgid "Invalid Address"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:527
+#: lib/Dynamic/Mailbox.php:526
 msgid "Invalid Subject"
 msgstr ""
 
-#: lib/Compose.php:1528
+#: lib/Compose.php:1529
 #, php-format
 msgid "Invalid e-mail address (%s)."
 msgstr ""
 
-#: lib/Compose.php:1524
+#: lib/Compose.php:1525
 #, php-format
 msgid "Invalid e-mail address (%s): %s"
 msgstr ""
 
-#: lib/Compose.php:775
+#: lib/Compose.php:776
 msgid "Invalid e-mail address."
 msgstr ""
 
@@ -2295,27 +2337,27 @@ msgstr ""
 msgid "Junk"
 msgstr ""
 
-#: lib/Pgp.php:805
+#: lib/Pgp.php:844
 msgid "Key Creation"
 msgstr ""
 
-#: lib/Pgp.php:812
+#: lib/Pgp.php:851
 msgid "Key Fingerprint"
 msgstr ""
 
-#: lib/Pgp.php:811
+#: lib/Pgp.php:850
 msgid "Key ID"
 msgstr ""
 
-#: lib/Pgp.php:807
+#: lib/Pgp.php:846
 msgid "Key Length"
 msgstr ""
 
-#: lib/Pgp.php:804
+#: lib/Pgp.php:843
 msgid "Key Type"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:96
+#: lib/Prefs/Special/PgpPrivateKey.php:94
 msgid ""
 "Key generation may take a long time to complete.  Continue with key "
 "generation?"
@@ -2333,7 +2375,7 @@ msgid ""
 "contacts."
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:166
+#: lib/Prefs/Special/PgpPrivateKey.php:164
 msgid "Key successfully sent to the public keyserver."
 msgstr ""
 
@@ -2342,11 +2384,11 @@ msgstr ""
 msgid "Label"
 msgstr ""
 
-#: config/prefs.php:1442
+#: config/prefs.php:1455
 msgid "Last (newest) Unseen Message"
 msgstr ""
 
-#: config/prefs.php:1444
+#: config/prefs.php:1457
 msgid "Last Page"
 msgstr ""
 
@@ -2354,7 +2396,7 @@ msgstr ""
 msgid "List"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:472 templates/dynamic/message.html.php:63
+#: lib/Dynamic/Mailbox.php:471 templates/dynamic/message.html.php:63
 #: templates/dynamic/message.html.php:65
 msgid "List Info"
 msgstr ""
@@ -2363,11 +2405,15 @@ msgstr ""
 msgid "Load All Addresses"
 msgstr ""
 
-#: lib/Smartmobile.php:180
+#: lib/Smartmobile.php:182
 msgid "Load More Messages..."
 msgstr ""
 
-#: lib/Mime/Viewer/Html.php:238
+#: lib/Mime/Viewer/Html.php:237
+msgid "Load Remote Images?"
+msgstr ""
+
+#: lib/Mime/Viewer/Html.php:244
 msgid "Load Styling?"
 msgstr ""
 
@@ -2375,14 +2421,14 @@ msgstr ""
 msgid "Load a Recent Search"
 msgstr ""
 
-#: lib/Mime/Viewer/Html.php:210
+#: lib/Mime/Viewer/Html.php:211
 msgid "Load message styling..."
 msgstr ""
 
 #: lib/Basic/Search.php:505 lib/Dynamic/Compose/Common.php:258
-#: lib/Dynamic/Mailbox.php:540 lib/Mime/Viewer/Html.php:82
+#: lib/Dynamic/Mailbox.php:539 lib/Mime/Viewer/Html.php:82
 #: lib/Mime/Viewer/Images.php:132 templates/dynamic/compose-base.html.php:4
-#: templates/dynamic/compose.html.php:212 templates/dynamic/mailbox.html.php:2
+#: templates/dynamic/compose.html.php:216 templates/dynamic/mailbox.html.php:2
 #: templates/dynamic/mailbox.html.php:305
 #: templates/dynamic/mailbox_subinfo.html.php:5
 #: templates/dynamic/message.html.php:4 templates/dynamic/sidebar.html.php:1
@@ -2394,7 +2440,7 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:256
+#: lib/Dynamic/Mailbox.php:255
 msgid "Log Out"
 msgstr ""
 
@@ -2403,7 +2449,7 @@ msgstr ""
 msgid "Logged out of %s."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:549
+#: lib/Dynamic/Mailbox.php:548
 msgid "Logging Out..."
 msgstr ""
 
@@ -2419,12 +2465,12 @@ msgstr ""
 msgid "Macintosh File"
 msgstr ""
 
-#: smartmobile.php:23
+#: smartmobile.php:24
 msgid "Mail"
 msgstr ""
 
-#: config/prefs.php:1411 config/prefs.php:1512 lib/Block/Summary.php:108
-#: lib/Mailbox.php:1826 templates/smartmobile/message.html.php:2
+#: config/prefs.php:1424 config/prefs.php:1525 lib/Block/Summary.php:108
+#: lib/Mailbox.php:1845 templates/smartmobile/message.html.php:2
 msgid "Mailbox"
 msgstr ""
 
@@ -2438,11 +2484,11 @@ msgstr ""
 msgid "Mailbox %s does not exist."
 msgstr ""
 
-#: config/prefs.php:1412
+#: config/prefs.php:1425
 msgid "Mailbox Display"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:379
+#: lib/Dynamic/Mailbox.php:378
 msgid "Mailbox Size"
 msgstr ""
 
@@ -2471,19 +2517,19 @@ msgstr ""
 msgid "Mailing List Messages"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:518
+#: lib/Dynamic/Mailbox.php:517
 msgid "Manage Remote Accounts"
 msgstr ""
 
-#: config/prefs.php:763
+#: config/prefs.php:770
 msgid "Manage message drafts."
 msgstr ""
 
-#: config/prefs.php:817
+#: config/prefs.php:824
 msgid "Manage sent mail."
 msgstr ""
 
-#: config/prefs.php:168
+#: config/prefs.php:172
 msgid "Manage your saved searches"
 msgstr ""
 
@@ -2495,23 +2541,23 @@ msgstr ""
 msgid "Mark (Seen)"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:362
+#: lib/Dynamic/Mailbox.php:361
 msgid "Mark all as"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:321 lib/Dynamic/Mailbox.php:431
+#: lib/Dynamic/Mailbox.php:320 lib/Dynamic/Mailbox.php:430
 msgid "Mark as"
 msgstr ""
 
-#: config/prefs.php:1035
+#: config/prefs.php:1048
 msgid "Mark different levels of quoting with different colors?"
 msgstr ""
 
-#: config/prefs.php:1133
+#: config/prefs.php:1146
 msgid "Mark messages as seen when deleting?"
 msgstr ""
 
-#: config/prefs.php:1042
+#: config/prefs.php:1055
 msgid "Mark simple markup?"
 msgstr ""
 
@@ -2539,22 +2585,22 @@ msgstr ""
 msgid "Maximum size (bytes) of compose body"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:536
+#: lib/Dynamic/Mailbox.php:535
 msgid "Mbox or .eml file:"
 msgstr ""
 
-#: config/prefs.php:969 config/prefs.php:1114 config/prefs.php:1223
-#: config/prefs.php:1306 config/prefs.php:1353 config/prefs.php:1387
-#: lib/Compose.php:2255 lib/Contents.php:1298 lib/Dynamic/Message.php:150
+#: config/prefs.php:977 config/prefs.php:1127 config/prefs.php:1236
+#: config/prefs.php:1319 config/prefs.php:1366 config/prefs.php:1400
+#: lib/Compose.php:2256 lib/Contents.php:1305 lib/Dynamic/Message.php:149
 msgid "Message"
 msgstr ""
 
-#: lib/Ajax/Application/Handler/Common.php:659
+#: lib/Ajax/Application/Handler/Common.php:676
 #, php-format
 msgid "Message \"%s\" redirected successfully."
 msgstr ""
 
-#: lib/Ajax/Application/Handler/Common.php:573
+#: lib/Ajax/Application/Handler/Common.php:590
 #, php-format
 msgid "Message \"%s\" sent successfully."
 msgstr ""
@@ -2563,19 +2609,19 @@ msgstr ""
 msgid "Message Body"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:238
+#: lib/Dynamic/Mailbox.php:237
 msgid "Message Date"
 msgstr ""
 
-#: config/prefs.php:1461
+#: config/prefs.php:1474
 msgid "Message Size"
 msgstr ""
 
-#: lib/Contents/View.php:171
+#: lib/Contents/View.php:179
 msgid "Message Source"
 msgstr ""
 
-#: lib/Compose.php:2255
+#: lib/Compose.php:2256
 #, php-format
 msgid "Message from %s"
 msgstr ""
@@ -2592,26 +2638,26 @@ msgstr ""
 msgid "Message is Signed"
 msgstr ""
 
-#: lib/Ajax/Application/Handler/Common.php:659
+#: lib/Ajax/Application/Handler/Common.php:676
 msgid "Message redirected successfully."
 msgstr ""
 
-#: lib/Compose.php:1232 lib/Compose.php:1283
+#: lib/Compose.php:1233 lib/Compose.php:1284
 #, php-format
 msgid "Message sent successfully, but not saved to %s."
 msgstr ""
 
-#: lib/Ajax/Application/Handler/Common.php:571
+#: lib/Ajax/Application/Handler/Common.php:588
 msgid "Message sent successfully."
 msgstr ""
 
-#: lib/Mime/Viewer/Html.php:237
+#: lib/Mime/Viewer/Html.php:243
 msgid ""
 "Message styling has been suppressed in this message part since the style "
 "data lives on a remote server."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:558
+#: lib/Dynamic/Mailbox.php:557
 #, php-format
 msgid "Messages %d - %d"
 msgstr ""
@@ -2624,11 +2670,11 @@ msgstr ""
 msgid "Messages with Attachments"
 msgstr ""
 
-#: config/prefs.php:308
+#: config/prefs.php:315
 msgid "Minutes needed to consider a event as non-conflicting in iTip"
 msgstr ""
 
-#: config/prefs.php:1126
+#: config/prefs.php:1139
 msgid "Mobile view only"
 msgstr ""
 
@@ -2636,7 +2682,7 @@ msgstr ""
 msgid "Months"
 msgstr ""
 
-#: templates/smartmobile/compose.html.php:55
+#: templates/smartmobile/compose.html.php:57
 #: templates/smartmobile/folders.html.php:13
 #: templates/smartmobile/mailbox.html.php:14
 #: templates/smartmobile/message.html.php:26
@@ -2647,30 +2693,30 @@ msgstr ""
 msgid "Move"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:545
+#: lib/Dynamic/Mailbox.php:544
 #, php-format
 msgid "Move %s to %s"
 msgstr ""
 
-#: config/prefs.php:1139
+#: config/prefs.php:1152
 msgid ""
 "Move deleted messages to your Trash mailbox instead of marking them as "
 "deleted in the current mailbox?"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:103
+#: lib/Dynamic/Mailbox.php:102
 msgid "Move to Base Level"
 msgstr ""
 
-#: config/prefs.php:1270
+#: config/prefs.php:1283
 msgid "Move to Inbox"
 msgstr ""
 
-#: config/prefs.php:1259
+#: config/prefs.php:1272
 msgid "Move to Spam mailbox"
 msgstr ""
 
-#: lib/Contents.php:1301
+#: lib/Contents.php:1308
 msgid "Multipart"
 msgstr ""
 
@@ -2682,23 +2728,23 @@ msgstr ""
 msgid "Multiple messages can only be forwarded as attachments."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:548
+#: lib/Dynamic/Mailbox.php:547
 msgid "Must enter a folder name"
 msgstr ""
 
-#: lib/Smartmobile.php:181
+#: lib/Smartmobile.php:183
 msgid "Must enter a non-empty name for the new destination mailbox."
 msgstr ""
 
-#: config/prefs.php:1456
+#: config/prefs.php:1469
 msgid "NONE"
 msgstr ""
 
-#: lib/Pgp.php:803 templates/itip/action.html.php:79
+#: lib/Pgp.php:842 templates/itip/action.html.php:79
 msgid "Name"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:136
+#: lib/Prefs/Special/PgpPrivateKey.php:134
 msgid "Name and/or email cannot be empty"
 msgstr ""
 
@@ -2711,11 +2757,11 @@ msgstr ""
 msgid "Need at least one date in the date range search."
 msgstr ""
 
-#: lib/Compose.php:778
+#: lib/Compose.php:779
 msgid "Need at least one message recipient."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:848
+#: lib/Mime/Viewer/Itip.php:913
 msgid "Needs Action"
 msgstr ""
 
@@ -2723,12 +2769,12 @@ msgstr ""
 msgid "Negative Right"
 msgstr ""
 
-#: config/prefs.php:860 config/prefs.php:1191 config/prefs.php:1282
-#: config/prefs.php:1319 lib/Pgp.php:843
+#: config/prefs.php:867 config/prefs.php:1204 config/prefs.php:1295
+#: config/prefs.php:1332 lib/Pgp.php:882
 msgid "Never"
 msgstr ""
 
-#: config/prefs.php:1096
+#: config/prefs.php:1109
 msgid "Never send read receipt"
 msgstr ""
 
@@ -2736,13 +2782,13 @@ msgstr ""
 msgid "New Flag"
 msgstr ""
 
-#: config/prefs.php:1307
+#: config/prefs.php:1320
 msgid "New Mail"
 msgstr ""
 
-#: lib/Application.php:313 lib/Compose.php:2375 lib/Dynamic/Base.php:155
-#: lib/Dynamic/Compose.php:79 lib/Dynamic/Mailbox.php:115
-#: lib/Smartmobile.php:183 templates/dynamic/mailbox.html.php:54
+#: lib/Application.php:320 lib/Compose.php:2376 lib/Dynamic/Base.php:157
+#: lib/Dynamic/Compose.php:79 lib/Dynamic/Mailbox.php:114
+#: lib/Smartmobile.php:185 templates/dynamic/mailbox.html.php:54
 #: templates/smartmobile/compose.html.php:2
 #: templates/smartmobile/folders.html.php:11
 #: templates/smartmobile/mailbox.html.php:11
@@ -2763,7 +2809,7 @@ msgstr ""
 msgid "New User"
 msgstr ""
 
-#: config/prefs.php:1326
+#: config/prefs.php:1339
 msgid "New mail poll interval on mailbox page:"
 msgstr ""
 
@@ -2775,18 +2821,22 @@ msgstr ""
 msgid "Newest Unseen Messages"
 msgstr ""
 
-#: lib/Prefs/Special/Remote.php:50 templates/prefs/remote.html.php:78
+#: lib/Prefs/Special/Remote.php:48 templates/prefs/remote.html.php:78
 #: templates/smartmobile/message.html.php:77
 msgid "Next"
 msgstr ""
 
-#: config/prefs.php:583 config/prefs.php:803 config/prefs.php:830
-#: config/prefs.php:1534
+#: config/prefs.php:590 config/prefs.php:810 config/prefs.php:837
+#: config/prefs.php:1547
 msgid "No"
 msgstr ""
 
 #: templates/prefs/pgpprivatekey.html.php:111
 msgid "No Expiration"
+msgstr ""
+
+#: lib/Auth.php:128
+msgid "No IMAP backend is available for auto-login."
 msgstr ""
 
 #: templates/prefs/pgppublickey.html.php:28
@@ -2810,7 +2860,7 @@ msgstr ""
 msgid "No Saved Searches Defined."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:267
+#: lib/Dynamic/Mailbox.php:266
 msgid "No Sort"
 msgstr ""
 
@@ -2822,7 +2872,7 @@ msgstr ""
 msgid "No Subject"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:250
+#: lib/Dynamic/Mailbox.php:249
 msgid "No actions available"
 msgstr ""
 
@@ -2830,7 +2880,7 @@ msgstr ""
 msgid "No addresses were selected."
 msgstr ""
 
-#: lib/Smime.php:283
+#: lib/Smime.php:333
 msgid "No email information located in the public key."
 msgstr ""
 
@@ -2842,7 +2892,7 @@ msgstr ""
 msgid "No mailboxes with unseen messages"
 msgstr ""
 
-#: lib/Compose.php:2286
+#: lib/Compose.php:2287
 msgid "No message body text"
 msgstr ""
 
@@ -2850,11 +2900,11 @@ msgstr ""
 msgid "No message index given."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:541 lib/Smartmobile.php:177
+#: lib/Dynamic/Mailbox.php:540 lib/Smartmobile.php:179
 msgid "No messages"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:561
+#: lib/Dynamic/Mailbox.php:560
 msgid "No messages matched the search query."
 msgstr ""
 
@@ -2882,17 +2932,17 @@ msgstr ""
 msgid "No unread messages"
 msgstr ""
 
-#: lib/Pgp.php:247
+#: lib/Pgp.php:286
 msgid "No valid public key found."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:897
+#: lib/Mime/Viewer/Itip.php:962
 msgid "Non Participant"
 msgstr ""
 
-#: lib/Compose/Ui.php:57 lib/Mime/Viewer/Itip.php:435
-#: lib/Mime/Viewer/Itip.php:620 lib/Mime/Viewer/Itip.php:788 lib/Pgp.php:845
-#: lib/Pgp.php:846 templates/prefs/acl.html.php:39
+#: lib/Compose/Ui.php:57 lib/Mime/Viewer/Itip.php:503
+#: lib/Mime/Viewer/Itip.php:688 lib/Mime/Viewer/Itip.php:853 lib/Pgp.php:884
+#: lib/Pgp.php:885 templates/prefs/acl.html.php:39
 #: templates/prefs/acl.html.php:74 templates/prefs/composetemplates.html.php:7
 #: templates/prefs/drafts.html.php:7 templates/prefs/sentmail.html.php:7
 #: templates/prefs/spam.html.php:7 templates/prefs/trash.html.php:7
@@ -2912,7 +2962,7 @@ msgstr ""
 msgid "Not Junk"
 msgstr ""
 
-#: lib/Smime.php:276
+#: lib/Smime.php:326
 msgid "Not a valid public key."
 msgstr ""
 
@@ -2920,7 +2970,7 @@ msgstr ""
 msgid "Notepads"
 msgstr ""
 
-#: config/prefs.php:1255 config/prefs.php:1269
+#: config/prefs.php:1268 config/prefs.php:1282
 msgid "Nothing"
 msgstr ""
 
@@ -2946,7 +2996,7 @@ msgstr ""
 msgid "Older Than"
 msgstr ""
 
-#: lib/Search/Element/Daterange.php:115
+#: lib/Search/Element/Daterange.php:116
 #, php-format
 msgid "On '%s'"
 msgstr ""
@@ -2959,11 +3009,11 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: lib/Mailbox.php:1771
+#: lib/Mailbox.php:1790
 msgid "Opened Folder"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:893
+#: lib/Mime/Viewer/Itip.php:958
 msgid "Optional Participant"
 msgstr ""
 
@@ -2980,23 +3030,23 @@ msgstr ""
 msgid "Other Options"
 msgstr ""
 
-#: lib/Mailbox.php:1659
+#: lib/Mailbox.php:1678
 msgid "Other Users"
 msgstr ""
 
-#: config/prefs.php:317
+#: config/prefs.php:324
 msgid "PGP"
 msgstr ""
 
-#: lib/Pgp.php:75
+#: lib/Pgp.php:88
 msgid "PGP Encrypt Message"
 msgstr ""
 
-#: lib/Pgp.php:86
+#: lib/Pgp.php:99
 msgid "PGP Encrypt Message with passphrase"
 msgstr ""
 
-#: lib/Compose.php:1100
+#: lib/Compose.php:1101
 msgid "PGP Error: "
 msgstr ""
 
@@ -3009,7 +3059,7 @@ msgstr ""
 msgid "PGP Public Key for \"%s (%s)\" was successfully added."
 msgstr ""
 
-#: lib/Prefs/Special/PgpPublicKey.php:107
+#: lib/Prefs/Special/PgpPublicKey.php:105
 #, php-format
 msgid "PGP Public Key for \"%s\" was successfully deleted."
 msgstr ""
@@ -3018,34 +3068,34 @@ msgstr ""
 msgid "PGP Public Keyring"
 msgstr ""
 
-#: lib/Pgp.php:80
+#: lib/Pgp.php:93
 msgid "PGP Sign Message"
 msgstr ""
 
-#: lib/Pgp.php:81
+#: lib/Pgp.php:94
 msgid "PGP Sign/Encrypt Message"
 msgstr ""
 
-#: lib/Pgp.php:87
+#: lib/Pgp.php:100
 msgid "PGP Sign/Encrypt Message with passphrase"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:172
+#: lib/Prefs/Special/PgpPrivateKey.php:170
 msgid "PGP passphrase successfully unloaded."
 msgstr ""
 
-#: config/prefs.php:344
+#: config/prefs.php:351
 msgid ""
 "PGP support requires popup windows to be used.  If your browser is currently "
 "set to disable popup windows, you must change this setting or else the PGP "
 "features will not work correctly."
 msgstr ""
 
-#: lib/Compose.php:1048
+#: lib/Compose.php:1049
 msgid "PGP: Need passphrase for personal private key."
 msgstr ""
 
-#: lib/Compose.php:1065
+#: lib/Compose.php:1066
 msgid "PGP: Need passphrase to encrypt your message with."
 msgstr ""
 
@@ -3069,11 +3119,11 @@ msgstr ""
 msgid "Passphrase verified."
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:139
+#: lib/Prefs/Special/PgpPrivateKey.php:137
 msgid "Passphrases cannot be empty"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:141
+#: lib/Prefs/Special/PgpPrivateKey.php:139
 msgid "Passphrases do not match"
 msgstr ""
 
@@ -3081,7 +3131,7 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:552
+#: lib/Dynamic/Mailbox.php:551
 #, php-format
 msgid "Password for %s:"
 msgstr ""
@@ -3107,12 +3157,12 @@ msgstr ""
 msgid "Percent complete"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:533
+#: lib/Dynamic/Mailbox.php:532
 #, php-format
 msgid "Permanently delete %s?"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:535
+#: lib/Dynamic/Mailbox.php:534
 #, php-format
 msgid "Permanently delete all %d messages in %s?"
 msgstr ""
@@ -3121,7 +3171,7 @@ msgstr ""
 msgid "Personal"
 msgstr ""
 
-#: config/prefs.php:15
+#: config/prefs.php:19
 msgid "Personal Information"
 msgstr ""
 
@@ -3138,11 +3188,11 @@ msgstr ""
 msgid "Personal PGP key successfully added."
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:158
+#: lib/Prefs/Special/PgpPrivateKey.php:156
 msgid "Personal PGP keypair generated successfully."
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:122
+#: lib/Prefs/Special/PgpPrivateKey.php:120
 msgid "Personal PGP keys deleted successfully."
 msgstr ""
 
@@ -3154,19 +3204,19 @@ msgstr ""
 msgid "Personal S/MIME certificates NOT imported: "
 msgstr ""
 
-#: lib/Prefs/Special/SmimePrivateKey.php:171
+#: lib/Prefs/Special/SmimePrivateKey.php:172
 msgid "Personal S/MIME keys deleted successfully."
 msgstr ""
 
-#: config/prefs.php:518
+#: config/prefs.php:525
 msgid "Plain Text"
 msgstr ""
 
-#: lib/Compose.php:1857
+#: lib/Compose.php:1858
 msgid "Plaintext Message"
 msgstr ""
 
-#: config/prefs.php:998
+#: config/prefs.php:1006
 msgid "Plaintext part"
 msgstr ""
 
@@ -3176,7 +3226,7 @@ msgid ""
 "embedded sound files, some may require a plugin."
 msgstr ""
 
-#: lib/Application.php:222
+#: lib/Application.php:229
 msgid "Please choose a mail server."
 msgstr ""
 
@@ -3192,11 +3242,11 @@ msgstr ""
 msgid "Please select at least one search criteria."
 msgstr ""
 
-#: lib/Prefs/Special/Remote.php:51
+#: lib/Prefs/Special/Remote.php:49
 msgid "Please wait..."
 msgstr ""
 
-#: config/prefs.php:1571
+#: config/prefs.php:1584
 msgid "Poll all mailboxes for new mail?"
 msgstr ""
 
@@ -3204,7 +3254,7 @@ msgstr ""
 msgid "Port"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:550
+#: lib/Dynamic/Mailbox.php:549
 msgid "Portal"
 msgstr ""
 
@@ -3221,7 +3271,7 @@ msgstr ""
 msgid "Post to this mailbox (not enforced by IMAP)"
 msgstr ""
 
-#: config/prefs.php:62
+#: config/prefs.php:66
 msgid "Precede your text signature with dashes ('-- ')?"
 msgstr ""
 
@@ -3229,15 +3279,15 @@ msgstr ""
 msgid "Previous"
 msgstr ""
 
-#: lib/Contents.php:858 lib/Contents.php:859
+#: lib/Contents.php:860 lib/Contents.php:861
 msgid "Print"
 msgstr ""
 
-#: lib/Contents/View.php:249
+#: lib/Contents/View.php:255
 msgid "Printed By"
 msgstr ""
 
-#: config/prefs.php:1388
+#: config/prefs.php:1401
 msgid "Printing"
 msgstr ""
 
@@ -3245,21 +3295,21 @@ msgstr ""
 msgid "Priority"
 msgstr ""
 
-#: lib/Pgp.php:841
+#: lib/Pgp.php:880
 msgid "Private Key"
 msgstr ""
 
-#: config/prefs.php:1102
+#: config/prefs.php:1115
 msgid ""
 "Prompt to send read receipt (a/k/a message disposition notification) when "
 "requested by the sender?"
 msgstr ""
 
-#: lib/Pgp.php:841
+#: lib/Pgp.php:880
 msgid "Public Key"
 msgstr ""
 
-#: lib/Pgp.php:971
+#: lib/Pgp.php:1010
 msgid "Public PGP keyserver support has been disabled."
 msgstr ""
 
@@ -3267,15 +3317,15 @@ msgstr ""
 msgid "Purge"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:438 templates/smartmobile/mailbox.html.php:30
+#: lib/Dynamic/Mailbox.php:437 templates/smartmobile/mailbox.html.php:30
 msgid "Purge Deleted"
 msgstr ""
 
-#: config/prefs.php:1283
+#: config/prefs.php:1296
 msgid "Purge Spam mailbox how often:"
 msgstr ""
 
-#: config/prefs.php:1192
+#: config/prefs.php:1205
 msgid "Purge Trash how often:"
 msgstr ""
 
@@ -3283,19 +3333,19 @@ msgstr ""
 msgid "Purge messages"
 msgstr ""
 
-#: config/prefs.php:1293
+#: config/prefs.php:1306
 msgid "Purge messages in Spam mailbox older than this amount of days."
 msgstr ""
 
-#: config/prefs.php:1204
+#: config/prefs.php:1217
 msgid "Purge messages in Trash mailbox older than this amount of days."
 msgstr ""
 
-#: config/prefs.php:871
+#: config/prefs.php:878
 msgid "Purge messages in sent mail mailbox(es) older than this amount of days."
 msgstr ""
 
-#: config/prefs.php:861
+#: config/prefs.php:868
 msgid "Purge sent mail how often:"
 msgstr ""
 
@@ -3323,7 +3373,7 @@ msgstr ""
 msgid "Purging 1 message from sent-mail mailbox %s."
 msgstr ""
 
-#: config/prefs.php:706
+#: config/prefs.php:713
 #, php-format
 msgid "Quoting %f:"
 msgstr ""
@@ -3350,7 +3400,7 @@ msgstr ""
 msgid "Rebuild"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:298
+#: lib/Dynamic/Mailbox.php:297
 msgid "Rebuild Folder List"
 msgstr ""
 
@@ -3358,7 +3408,7 @@ msgstr ""
 msgid "Recent Searches"
 msgstr ""
 
-#: lib/Compose.php:797
+#: lib/Compose.php:798
 msgid "Recipient address does not match the currently selected identity."
 msgstr ""
 
@@ -3367,7 +3417,7 @@ msgstr ""
 msgid "Recipient: %s"
 msgstr ""
 
-#: lib/Basic/Search.php:60 lib/Dynamic/Mailbox.php:497
+#: lib/Basic/Search.php:60 lib/Dynamic/Mailbox.php:496
 #: templates/smartmobile/search.html.php:12
 msgid "Recipients (To/Cc/Bcc)"
 msgstr ""
@@ -3377,11 +3427,15 @@ msgstr ""
 msgid "Recipients (To/Cc/Bcc) for '%s'"
 msgstr ""
 
+#: lib/Mime/Viewer/Itip.php:425
+msgid "Record proposed new time"
+msgstr ""
+
 #: templates/itip/action.html.php:67
 msgid "Recurrence"
 msgstr ""
 
-#: lib/Dynamic/Base.php:178 lib/Dynamic/Compose.php:150
+#: lib/Dynamic/Base.php:180 lib/Dynamic/Compose.php:150
 #: lib/Notification/Event/Status.php:33 templates/dynamic/redirect.html.php:7
 #: templates/smartmobile/message.html.php:55
 msgid "Redirect"
@@ -3397,36 +3451,44 @@ msgstr ""
 msgid "Refresh Search Results"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:255
+#: lib/Mime/Viewer/Itip.php:256
 msgid "Remember the free/busy information."
 msgstr ""
 
-#: config/prefs.php:1536
+#: config/prefs.php:1549
 msgid "Remember the last view"
 msgstr ""
 
-#: lib/Mailbox.php:1781
+#: lib/Mailbox.php:1800
 msgid "Remote Account"
 msgstr ""
 
-#: config/prefs.php:140 lib/Mailbox.php:1655
+#: config/prefs.php:144 lib/Mailbox.php:1674
 msgid "Remote Accounts"
+msgstr ""
+
+#: lib/Mime/Viewer/Html.php:236
+msgid "Remote images have been blocked in this message part."
 msgstr ""
 
 #: templates/contacts/contacts.html.php:50
 msgid "Remove"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:228 lib/Dynamic/Mailbox.php:358
+#: lib/Mime/Viewer/Itip.php:448
+msgid "Remove proposed new time from my calendar"
+msgstr ""
+
+#: lib/Dynamic/Mailbox.php:227 lib/Dynamic/Mailbox.php:357
 msgid "Rename"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:553
+#: lib/Dynamic/Mailbox.php:552
 #, php-format
 msgid "Rename %s to:"
 msgstr ""
 
-#: config/prefs.php:839
+#: config/prefs.php:846
 msgid "Rename sent mail mailbox at beginning of month?"
 msgstr ""
 
@@ -3435,11 +3497,11 @@ msgstr ""
 msgid "Renaming \"%s\" to \"%s\" failed. This is what the server said"
 msgstr ""
 
-#: config/prefs.php:671
+#: config/prefs.php:678
 msgid "Replies"
 msgstr ""
 
-#: lib/Dynamic/Compose.php:105 lib/Dynamic/Mailbox.php:317
+#: lib/Dynamic/Compose.php:105 lib/Dynamic/Mailbox.php:316
 #: lib/Notification/Event/Status.php:40 templates/dynamic/mailbox.html.php:29
 #: templates/dynamic/message.html.php:12
 msgid "Reply"
@@ -3449,7 +3511,7 @@ msgstr ""
 msgid "Reply (Auto)"
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:330 lib/Ajax/Imple/ItipRequest.php:443
+#: lib/Ajax/Imple/ItipRequest.php:415 lib/Ajax/Imple/ItipRequest.php:528
 msgid "Reply Sent."
 msgstr ""
 
@@ -3470,19 +3532,19 @@ msgstr ""
 msgid "Reply to Sender"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:258 lib/Mime/Viewer/Itip.php:267
+#: lib/Mime/Viewer/Itip.php:259 lib/Mime/Viewer/Itip.php:268
 msgid "Reply with Not Supported Message"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:265
+#: lib/Mime/Viewer/Itip.php:266
 msgid "Reply with free/busy for next 2 months."
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:264
+#: lib/Mime/Viewer/Itip.php:265
 msgid "Reply with requested free/busy information."
 msgstr ""
 
-#: lib/Compose.php:2767
+#: lib/Compose.php:2778
 msgid "Reply-To"
 msgstr ""
 
@@ -3495,15 +3557,15 @@ msgstr ""
 msgid "Report"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:326 templates/smartmobile/message.html.php:85
+#: lib/Dynamic/Mailbox.php:325 templates/smartmobile/message.html.php:85
 msgid "Report as Innocent"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:325 templates/smartmobile/message.html.php:100
+#: lib/Dynamic/Mailbox.php:324 templates/smartmobile/message.html.php:100
 msgid "Report as Spam"
 msgstr ""
 
-#: config/prefs.php:586
+#: config/prefs.php:593
 msgid "Request read receipts?"
 msgstr ""
 
@@ -3515,11 +3577,11 @@ msgstr ""
 msgid "Required"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:885
+#: lib/Mime/Viewer/Itip.php:950
 msgid "Required Participant"
 msgstr ""
 
-#: lib/Dynamic/Base.php:194
+#: lib/Dynamic/Base.php:196
 #, php-format
 msgid "Resent on %s by:"
 msgstr ""
@@ -3528,12 +3590,12 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:138 lib/Ajax/Imple/ItipRequest.php:156
-#: lib/Mime/Viewer/Itip.php:375 lib/Mime/Viewer/Itip.php:767
+#: lib/Ajax/Imple/ItipRequest.php:150 lib/Ajax/Imple/ItipRequest.php:170
+#: lib/Mime/Viewer/Itip.php:400 lib/Mime/Viewer/Itip.php:832
 msgid "Respondent Status Updated."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:556
+#: lib/Dynamic/Mailbox.php:555
 #, php-format
 msgid "Results are %d Minutes Old"
 msgstr ""
@@ -3542,7 +3604,7 @@ msgstr ""
 msgid "Resume"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:312 templates/dynamic/mailbox.html.php:114
+#: lib/Dynamic/Mailbox.php:311 templates/dynamic/mailbox.html.php:114
 msgid "Resume Draft"
 msgstr ""
 
@@ -3559,12 +3621,12 @@ msgstr ""
 msgid "Return to %s"
 msgstr ""
 
-#: config/prefs.php:1126
+#: config/prefs.php:1139
 msgid ""
 "Return to the mailbox listing after deleting, moving, or copying a message?"
 msgstr ""
 
-#: config/prefs.php:519
+#: config/prefs.php:526
 msgid "Rich Text (HTML)"
 msgstr ""
 
@@ -3572,19 +3634,19 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: config/prefs.php:400
+#: config/prefs.php:407
 msgid "S/MIME"
 msgstr ""
 
-#: lib/Smime.php:88
+#: lib/Smime.php:102
 msgid "S/MIME Encrypt Message"
 msgstr ""
 
-#: lib/Compose.php:1149
+#: lib/Compose.php:1150
 msgid "S/MIME Error: "
 msgstr ""
 
-#: lib/Compose.php:1125
+#: lib/Compose.php:1126
 msgid "S/MIME Error: Need passphrase for personal private key."
 msgstr ""
 
@@ -3596,7 +3658,7 @@ msgstr ""
 msgid "S/MIME Personal Certificate support requires a secure web connection."
 msgstr ""
 
-#: lib/Prefs/Special/SmimePublicKey.php:105
+#: lib/Prefs/Special/SmimePublicKey.php:103
 #, php-format
 msgid "S/MIME Public Key for \"%s\" was successfully deleted."
 msgstr ""
@@ -3609,15 +3671,15 @@ msgstr ""
 msgid "S/MIME Public/Private Keypair successfully added."
 msgstr ""
 
-#: lib/Smime.php:94
+#: lib/Smime.php:108
 msgid "S/MIME Sign Message"
 msgstr ""
 
-#: lib/Smime.php:95
+#: lib/Smime.php:109
 msgid "S/MIME Sign/Encrypt Message"
 msgstr ""
 
-#: lib/Prefs/Special/SmimePrivateKey.php:180
+#: lib/Prefs/Special/SmimePrivateKey.php:181
 msgid "S/MIME passphrase successfully unloaded."
 msgstr ""
 
@@ -3637,14 +3699,14 @@ msgid ""
 "verified."
 msgstr ""
 
-#: config/prefs.php:428
+#: config/prefs.php:435
 msgid ""
 "S/MIME support requires popup windows to be used.  If your browser is "
 "currently set to disable popup windows, you must change this setting or else "
 "the S/MIME features will not work correctly."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:468 templates/dynamic/message.html.php:48
+#: lib/Dynamic/Mailbox.php:467 templates/dynamic/message.html.php:48
 #: templates/dynamic/message.html.php:50 templates/prefs/remote.html.php:79
 #: templates/search/search.html.php:101
 msgid "Save"
@@ -3654,7 +3716,7 @@ msgstr ""
 msgid "Save Attachments in Sent Mailbox"
 msgstr ""
 
-#: templates/smartmobile/compose.html.php:62
+#: templates/smartmobile/compose.html.php:64
 msgid "Save Draft"
 msgstr ""
 
@@ -3662,7 +3724,7 @@ msgstr ""
 msgid "Save Image"
 msgstr ""
 
-#: lib/Contents.php:850
+#: lib/Contents.php:852
 msgid "Save Image in Gallery"
 msgstr ""
 
@@ -3678,11 +3740,11 @@ msgstr ""
 msgid "Save as Draft"
 msgstr ""
 
-#: config/prefs.php:794
+#: config/prefs.php:801
 msgid "Save drafts as unseen?"
 msgstr ""
 
-#: config/prefs.php:807
+#: config/prefs.php:814
 msgid "Save drafts automatically while composing?"
 msgstr ""
 
@@ -3694,7 +3756,7 @@ msgstr ""
 msgid "Save password?"
 msgstr ""
 
-#: config/prefs.php:900
+#: config/prefs.php:907
 msgid "Save recipients automatically to the default address book?"
 msgstr ""
 
@@ -3702,7 +3764,7 @@ msgstr ""
 msgid "Save sent mail"
 msgstr ""
 
-#: config/prefs.php:90
+#: config/prefs.php:94
 msgid "Save sent mail?"
 msgstr ""
 
@@ -3714,7 +3776,7 @@ msgstr ""
 msgid "Save the key to your address book."
 msgstr ""
 
-#: config/prefs.php:167
+#: config/prefs.php:171
 msgid "Saved Searches"
 msgstr ""
 
@@ -3722,30 +3784,30 @@ msgstr ""
 msgid "Saved searches require a label."
 msgstr ""
 
-#: lib/Compose.php:343
+#: lib/Compose.php:344
 msgid "Saving the draft failed. Could not create a drafts mailbox."
 msgstr ""
 
-#: lib/Compose.php:338
+#: lib/Compose.php:339
 msgid "Saving the draft failed. No drafts mailbox specified."
 msgstr ""
 
-#: lib/Compose.php:271
+#: lib/Compose.php:272
 #, php-format
 msgid ""
 "Saving the message failed because it contains an invalid e-mail address: %s."
 msgstr ""
 
-#: lib/Compose.php:676
+#: lib/Compose.php:677
 msgid "Saving the template failed: could not create the templates mailbox."
 msgstr ""
 
-#: lib/Compose.php:671
+#: lib/Compose.php:672
 msgid "Saving the template failed: no template mailbox exists."
 msgstr ""
 
-#: lib/Application.php:341 lib/Basic/Search.php:527 lib/Dynamic/Mailbox.php:231
-#: lib/Dynamic/Mailbox.php:369 lib/Dynamic/Mailbox.php:554
+#: lib/Application.php:348 lib/Basic/Search.php:527 lib/Dynamic/Mailbox.php:230
+#: lib/Dynamic/Mailbox.php:368 lib/Dynamic/Mailbox.php:553
 #: templates/contacts/contacts.html.php:21 templates/search/search.html.php:11
 #: templates/smartmobile/mailbox.html.php:22
 #: templates/smartmobile/search.html.php:3
@@ -3757,12 +3819,12 @@ msgstr ""
 msgid "Search %s"
 msgstr ""
 
-#: lib/Search/Query.php:290
+#: lib/Search/Query.php:306
 #, php-format
 msgid "Search %s in %s"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:555
+#: lib/Dynamic/Mailbox.php:554
 #, php-format
 msgid "Search (%s)"
 msgstr ""
@@ -3779,7 +3841,7 @@ msgstr ""
 msgid "Search Mailboxes"
 msgstr ""
 
-#: lib/Search/Query.php:143 lib/Smartmobile.php:186
+#: lib/Search/Query.php:150 lib/Smartmobile.php:188
 #: templates/contacts/contacts.html.php:28
 msgid "Search Results"
 msgstr ""
@@ -3808,11 +3870,11 @@ msgstr ""
 msgid "Secondary personal S/MIME certificates NOT imported: "
 msgstr ""
 
-#: lib/Prefs/Special/SmimePrivateKey.php:170
+#: lib/Prefs/Special/SmimePrivateKey.php:171
 msgid "Secondary personal S/MIME keys deleted successfully."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:244 lib/Flag/Imap/Seen.php:43
+#: lib/Dynamic/Mailbox.php:243 lib/Flag/Imap/Seen.php:43
 msgid "Seen"
 msgstr ""
 
@@ -3825,7 +3887,7 @@ msgstr ""
 msgid "Select All"
 msgstr ""
 
-#: config/prefs.php:886
+#: config/prefs.php:893
 msgid "Select address book sources for adding/searching."
 msgstr ""
 
@@ -3845,20 +3907,20 @@ msgstr ""
 msgid "Send"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:60
+#: lib/Prefs/Special/PgpPrivateKey.php:58
 #: templates/prefs/pgpprivatekey.html.php:23
 msgid "Send Key to Public Keyserver"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:359
+#: lib/Mime/Viewer/Itip.php:387
 msgid "Send Latest Information"
 msgstr ""
 
-#: templates/smartmobile/compose.html.php:53
+#: templates/smartmobile/compose.html.php:55
 msgid "Send Message"
 msgstr ""
 
-#: lib/Smartmobile.php:185
+#: lib/Smartmobile.php:187
 msgid "Send message without a Subject?"
 msgstr ""
 
@@ -3871,7 +3933,7 @@ msgstr ""
 msgid "Sender: %s"
 msgstr ""
 
-#: lib/Mailbox.php:1708 lib/Mailbox.php:1820
+#: lib/Mailbox.php:1727 lib/Mailbox.php:1839
 msgid "Sent"
 msgstr ""
 
@@ -3880,7 +3942,7 @@ msgstr ""
 msgid "Sent Date: %s"
 msgstr ""
 
-#: config/prefs.php:816
+#: config/prefs.php:823
 msgid "Sent Mail"
 msgstr ""
 
@@ -3888,7 +3950,7 @@ msgstr ""
 msgid "Sent mail mailbox:"
 msgstr ""
 
-#: lib/Application.php:214 templates/prefs/remote.html.php:55
+#: lib/Application.php:221 templates/prefs/remote.html.php:55
 #: templates/prefs/remote.html.php:87
 msgid "Server"
 msgstr ""
@@ -3897,7 +3959,7 @@ msgstr ""
 msgid "Server Suggestion"
 msgstr ""
 
-#: config/prefs.php:511
+#: config/prefs.php:518
 msgid "Set a priority header when composing messages?"
 msgstr ""
 
@@ -3905,31 +3967,31 @@ msgstr ""
 msgid "Set permissions for other users"
 msgstr ""
 
-#: config/prefs.php:1116
+#: config/prefs.php:1129
 msgid "Set preferences for what happens when you move and delete messages."
 msgstr ""
 
-#: config/prefs.php:114
+#: config/prefs.php:118
 msgid "Share Mailboxes"
 msgstr ""
 
-#: config/prefs.php:115
+#: config/prefs.php:119
 msgid "Share your mailboxes with other users."
 msgstr ""
 
-#: lib/Mailbox.php:1661
+#: lib/Mailbox.php:1680
 msgid "Shared"
 msgstr ""
 
-#: config/prefs.php:360
+#: config/prefs.php:367
 msgid "Should PGP signed messages be automatically verified when viewed?"
 msgstr ""
 
-#: config/prefs.php:436
+#: config/prefs.php:443
 msgid "Should S/MIME signed messages be automatically verified when viewed?"
 msgstr ""
 
-#: config/prefs.php:352
+#: config/prefs.php:359
 msgid "Should your PGP public key to be attached to your messages by default?"
 msgstr ""
 
@@ -3947,19 +4009,19 @@ msgstr ""
 msgid "Show All"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:294
+#: lib/Dynamic/Mailbox.php:293
 msgid "Show All Mailboxes"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:441
+#: lib/Dynamic/Mailbox.php:440
 msgid "Show Deleted"
 msgstr ""
 
-#: lib/Mime/Viewer/Html.php:235
+#: lib/Mime/Viewer/Html.php:240
 msgid "Show Images?"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:483
+#: lib/Dynamic/Mailbox.php:482
 msgid "Show Only"
 msgstr ""
 
@@ -3967,7 +4029,7 @@ msgstr ""
 msgid "Show Polled"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:426
+#: lib/Dynamic/Mailbox.php:425
 msgid "Show Preview"
 msgstr ""
 
@@ -3975,39 +4037,47 @@ msgstr ""
 msgid "Show Unsubscribed Mailboxes"
 msgstr ""
 
-#: config/prefs.php:1076
+#: config/prefs.php:1089
 msgid "Show all attachments"
 msgstr ""
 
-#: config/prefs.php:1379
+#: config/prefs.php:1392
 msgid "Show all flags (including flags set by other mail programs)?"
 msgstr ""
 
-#: config/prefs.php:1075
+#: config/prefs.php:1020
+msgid "Show all images"
+msgstr ""
+
+#: config/prefs.php:1088
 msgid "Show all parts"
 msgstr ""
 
-#: lib/Mime/Viewer/Html.php:208
+#: lib/Mime/Viewer/Html.php:209
 msgid "Show images..."
 msgstr ""
 
-#: config/prefs.php:1550
+#: config/prefs.php:1022
+msgid "Show inline images, block remote images"
+msgstr ""
+
+#: config/prefs.php:1563
 msgid "Show non-private mailboxes in separate folders"
 msgstr ""
 
-#: config/prefs.php:84
+#: config/prefs.php:88
 msgid "Show the signature on the compose screen?"
 msgstr ""
 
-#: config/prefs.php:1049
+#: config/prefs.php:1062
 msgid "Shown"
 msgstr ""
 
-#: templates/dynamic/compose.html.php:201
+#: templates/dynamic/compose.html.php:203
 msgid "Signature"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:216 lib/Dynamic/Mailbox.php:265
+#: lib/Dynamic/Mailbox.php:215 lib/Dynamic/Mailbox.php:264
 #: templates/mime/compressed.html.php:9
 msgid "Size"
 msgstr ""
@@ -4032,7 +4102,7 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#: lib/Mailbox.php:1725 lib/Mailbox.php:1807
+#: lib/Mailbox.php:1744 lib/Mailbox.php:1826
 #: templates/dynamic/mailbox.html.php:36 templates/dynamic/message.html.php:19
 #: templates/smartmobile/mailbox.html.php:38
 #: templates/smartmobile/mailbox.html.php:48
@@ -4040,7 +4110,7 @@ msgstr ""
 msgid "Spam"
 msgstr ""
 
-#: config/prefs.php:1224
+#: config/prefs.php:1237
 msgid "Spam Reporting"
 msgstr ""
 
@@ -4064,23 +4134,23 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/Contents.php:875
+#: lib/Contents.php:877
 msgid "Strip Attachment"
 msgstr ""
 
-#: config/prefs.php:715
+#: config/prefs.php:722
 msgid "Strip the sender's signature from plaintext replies?"
 msgstr ""
 
-#: config/prefs.php:1460 lib/Basic/Search.php:76 lib/Compose.php:2771
-#: lib/Contents/View.php:225 lib/Dynamic/Mailbox.php:191
-#: lib/Dynamic/Mailbox.php:261 lib/Dynamic/Mailbox.php:498
-#: lib/Smartmobile.php:187 templates/dynamic/compose.html.php:144
+#: config/prefs.php:1473 lib/Basic/Search.php:76 lib/Compose.php:2782
+#: lib/Contents/View.php:231 lib/Dynamic/Mailbox.php:190
+#: lib/Dynamic/Mailbox.php:260 lib/Dynamic/Mailbox.php:497
+#: lib/Smartmobile.php:189 templates/dynamic/compose.html.php:144
 #: templates/smartmobile/search.html.php:13
 msgid "Subject"
 msgstr ""
 
-#: templates/smartmobile/compose.html.php:43
+#: templates/smartmobile/compose.html.php:45
 msgid "Subject:"
 msgstr ""
 
@@ -4090,16 +4160,16 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:366
+#: lib/Dynamic/Mailbox.php:365
 msgid "Subscribe"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:566
+#: lib/Dynamic/Mailbox.php:565
 #, php-format
 msgid "Subscribe to %s?"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:567
+#: lib/Dynamic/Mailbox.php:566
 #, php-format
 msgid "Subscribe to all subfolders of %s?"
 msgstr ""
@@ -4108,11 +4178,11 @@ msgstr ""
 msgid "Success"
 msgstr ""
 
-#: lib/Ajax/Imple/ImportEncryptKey.php:90
+#: lib/Ajax/Imple/ImportEncryptKey.php:92
 msgid "Successfully added certificate from message."
 msgstr ""
 
-#: lib/Ajax/Imple/ImportEncryptKey.php:78
+#: lib/Ajax/Imple/ImportEncryptKey.php:80
 msgid "Successfully added public key from message."
 msgstr ""
 
@@ -4129,24 +4199,24 @@ msgstr ""
 msgid "Task Lists"
 msgstr ""
 
-#: lib/Mailbox.php:1696 templates/prefs/acl.html.php:37
+#: lib/Mailbox.php:1715 templates/prefs/acl.html.php:37
 #: templates/prefs/acl.html.php:72
 msgid "Templates"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:345
+#: lib/Mime/Viewer/Itip.php:373
 msgid "Tentatively Accept request"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:834
+#: lib/Mime/Viewer/Itip.php:899
 msgid "Tentatively Accepted"
 msgstr ""
 
-#: lib/Contents.php:1304
+#: lib/Contents.php:1311
 msgid "Text"
 msgstr ""
 
-#: templates/smartmobile/compose.html.php:46
+#: templates/smartmobile/compose.html.php:48
 msgid "Text:"
 msgstr ""
 
@@ -4165,7 +4235,7 @@ msgstr ""
 msgid "The attachment limit has been reached."
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:81 lib/Mime/Viewer/Itip.php:104
+#: lib/Ajax/Imple/ItipRequest.php:84 lib/Mime/Viewer/Itip.php:104
 msgid "The calendar data is invalid"
 msgstr ""
 
@@ -4206,32 +4276,32 @@ msgstr ""
 msgid "The data in this part has been encrypted via S/MIME."
 msgstr ""
 
-#: config/prefs.php:531
+#: config/prefs.php:538
 msgid "The default font family to use in the HTML editor."
 msgstr ""
 
-#: config/prefs.php:540
+#: config/prefs.php:547
 msgid "The default font size to use in the HTML editor (in pixels)."
 msgstr ""
 
-#: lib/Compose.php:366
+#: lib/Compose.php:367
 #, php-format
 msgid "The draft has been saved to the \"%s\" mailbox."
 msgstr ""
 
-#: lib/Compose.php:368
+#: lib/Compose.php:369
 msgid "The draft was not successfully saved."
 msgstr ""
 
-#: lib/Prefs/Special/Remote.php:48
+#: lib/Prefs/Special/Remote.php:46
 msgid "The e-mail field cannot be empty."
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:519
+#: lib/Ajax/Imple/ItipRequest.php:665
 msgid "The event was added to your calendar."
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:496
+#: lib/Ajax/Imple/ItipRequest.php:642 lib/Mime/Viewer/Itip.php:350
 msgid "The event was updated in your calendar."
 msgstr ""
 
@@ -4245,7 +4315,7 @@ msgid ""
 "original sender or it may have expired."
 msgstr ""
 
-#: lib/Mime/Viewer/Html.php:185
+#: lib/Mime/Viewer/Html.php:186
 msgid "The links that caused this warning have this background color:"
 msgstr ""
 
@@ -4255,7 +4325,7 @@ msgid ""
 "(enter each address on a new line)"
 msgstr ""
 
-#: lib/Imap.php:770
+#: lib/Imap.php:792
 msgid "The mail server is not currently avaliable."
 msgstr ""
 
@@ -4304,7 +4374,7 @@ msgstr ""
 msgid "The mailbox \"%s\" was successfully renamed to \"%s\"."
 msgstr ""
 
-#: lib/Mailbox.php:1408
+#: lib/Mailbox.php:1421
 #, php-format
 msgid "The mailbox %s is already empty."
 msgstr ""
@@ -4323,7 +4393,7 @@ msgstr ""
 msgid "The message being composed has been closed."
 msgstr ""
 
-#: lib/Smartmobile.php:185
+#: lib/Smartmobile.php:187
 msgid "The message does not have a Subject entered."
 msgstr ""
 
@@ -4367,8 +4437,12 @@ msgstr ""
 msgid "The number of unseen messages to show"
 msgstr ""
 
-#: lib/Prefs/Special/Remote.php:49
+#: lib/Prefs/Special/Remote.php:47
 msgid "The password field cannot be empty."
+msgstr ""
+
+#: lib/Ajax/Imple/ItipRequest.php:243 lib/Mime/Viewer/Itip.php:442
+msgid "The proposed new time was removed from your calendar."
 msgstr ""
 
 #: templates/dynamic/compose.html.php:188
@@ -4381,31 +4455,31 @@ msgid ""
 "read this message."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:538
+#: lib/Dynamic/Mailbox.php:537
 msgid "The server is still generating the message list."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:539
+#: lib/Dynamic/Mailbox.php:538
 msgid "The server was unable to generate the message list."
 msgstr ""
 
-#: lib/Indices.php:316
+#: lib/Indices.php:317
 msgid "The source directory is read-only."
 msgstr ""
 
-#: lib/Indices.php:310
+#: lib/Indices.php:311
 msgid "The target directory is read-only."
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:254
+#: lib/Ajax/Imple/ItipRequest.php:339
 msgid "The task has been added to your tasklist."
 msgstr ""
 
-#: lib/Compose.php:702
+#: lib/Compose.php:703
 msgid "The template has been saved."
 msgstr ""
 
-#: lib/Compose.php:699
+#: lib/Compose.php:700
 msgid "The template was not successfully saved."
 msgstr ""
 
@@ -4415,23 +4489,23 @@ msgid ""
 "allowed."
 msgstr ""
 
-#: lib/Mbox/Import.php:146
+#: lib/Mbox/Import.php:151
 msgid "The uploaded file cannot be opened."
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:234 lib/Mime/Viewer/Itip.php:250
+#: lib/Ajax/Imple/ItipRequest.php:319 lib/Mime/Viewer/Itip.php:251
 msgid "The user's free/busy information was sucessfully stored."
 msgstr ""
 
-#: lib/Mime/Viewer/Alternative.php:99 lib/Mime/Viewer/Alternative.php:181
+#: lib/Mime/Viewer/Alternative.php:108 lib/Mime/Viewer/Alternative.php:190
 msgid "There are no alternative parts that can be displayed inline."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:560
+#: lib/Dynamic/Mailbox.php:559
 msgid "There are no messages in this mailbox."
 msgstr ""
 
-#: lib/Contents/Message.php:696
+#: lib/Contents/Message.php:697
 msgid "There are no parts that can be shown inline."
 msgstr ""
 
@@ -4439,90 +4513,103 @@ msgstr ""
 msgid "There is no text that can be displayed inline."
 msgstr ""
 
-#: lib/Indices.php:302
+#: lib/Ajax/Imple/ItipRequest.php:223
+#, php-format
+msgid "There was an error clearing the proposed new time: %s"
+msgstr ""
+
+#: lib/Indices.php:303
 #, php-format
 msgid ""
 "There was an error copying messages from \"%s\" to \"%s\". This is what the "
 "server said"
 msgstr ""
 
-#: lib/Indices.php:422
+#: lib/Indices.php:435
 #, php-format
 msgid "There was an error deleting messages from the mailbox \"%s\"."
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:119
+#: lib/Ajax/Imple/ItipRequest.php:122
 #, php-format
 msgid "There was an error deleting the event: %s"
 msgstr ""
 
-#: lib/Indices.php:760
+#: lib/Indices.php:789
 #, php-format
 msgid "There was an error flagging messages in the mailbox \"%s\": %s."
 msgstr ""
 
-#: lib/Mbox/Import.php:59
+#: lib/Mbox/Import.php:63
 #, php-format
 msgid "There was an error importing %s."
 msgstr ""
 
-#: lib/Ajax/Imple/VcardImport.php:97
+#: lib/Ajax/Imple/VcardImport.php:99
 msgid "There was an error importing the contact data:"
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:529
+#: lib/Ajax/Imple/ItipRequest.php:675
 #, php-format
 msgid "There was an error importing the event: %s"
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:263
+#: lib/Ajax/Imple/ItipRequest.php:348
 #, php-format
 msgid "There was an error importing the task: %s"
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:237 lib/Mime/Viewer/Itip.php:252
+#: lib/Ajax/Imple/ItipRequest.php:322 lib/Mime/Viewer/Itip.php:253
 #, php-format
 msgid "There was an error importing user's free/busy information: %s"
 msgstr ""
 
-#: lib/Indices.php:298
+#: lib/Indices.php:299
 #, php-format
 msgid ""
 "There was an error moving messages from \"%s\" to \"%s\". This is what the "
 "server said"
 msgstr ""
 
-#: lib/Compose.php:893
+#: lib/Ajax/Imple/ItipRequest.php:196
+#, php-format
+msgid "There was an error notifying attendees of the accepted proposal: %s"
+msgstr ""
+
+#: lib/Compose.php:894
 #, php-format
 msgid "There was an error sending your message: %s"
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:210
+#: lib/Ajax/Imple/ItipRequest.php:295
 #, php-format
 msgid "There was an error updating attendee status: %s"
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:142 lib/Mime/Viewer/Itip.php:377
+#: lib/Ajax/Imple/ItipRequest.php:156 lib/Ajax/Imple/ItipRequest.php:247
+#: lib/Mime/Viewer/Itip.php:360 lib/Mime/Viewer/Itip.php:402
+#: lib/Mime/Viewer/Itip.php:422 lib/Mime/Viewer/Itip.php:445
 #, php-format
 msgid "There was an error updating the event: %s"
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:506
+#: lib/Ajax/Imple/ItipRequest.php:652
 #, php-format
 msgid ""
 "There was an error updating the event: %s Trying to import the event instead."
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:160 lib/Mime/Viewer/Itip.php:769
+#: lib/Ajax/Imple/ItipRequest.php:174 lib/Mime/Viewer/Itip.php:834
 #, php-format
 msgid "There was an error updating the task: %s"
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:122 lib/Ajax/Imple/ItipRequest.php:145
-#: lib/Ajax/Imple/ItipRequest.php:163 lib/Ajax/Imple/ItipRequest.php:240
-#: lib/Ajax/Imple/ItipRequest.php:266 lib/Ajax/Imple/ItipRequest.php:272
-#: lib/Ajax/Imple/ItipRequest.php:336 lib/Ajax/Imple/ItipRequest.php:456
-#: lib/Ajax/Imple/ItipRequest.php:534
+#: lib/Ajax/Imple/ItipRequest.php:125 lib/Ajax/Imple/ItipRequest.php:159
+#: lib/Ajax/Imple/ItipRequest.php:177 lib/Ajax/Imple/ItipRequest.php:200
+#: lib/Ajax/Imple/ItipRequest.php:234 lib/Ajax/Imple/ItipRequest.php:250
+#: lib/Ajax/Imple/ItipRequest.php:325 lib/Ajax/Imple/ItipRequest.php:351
+#: lib/Ajax/Imple/ItipRequest.php:357 lib/Ajax/Imple/ItipRequest.php:421
+#: lib/Ajax/Imple/ItipRequest.php:541 lib/Ajax/Imple/ItipRequest.php:680
 msgid "This action is not supported."
 msgstr ""
 
@@ -4535,7 +4622,7 @@ msgstr ""
 msgid "This digitally signed message is broken."
 msgstr ""
 
-#: lib/Mime/Viewer/Tgz.php:76 lib/Mime/Viewer/Zip.php:86
+#: lib/Mime/Viewer/Tgz.php:76 lib/Mime/Viewer/Zip.php:89
 msgid "This is a compressed file."
 msgstr ""
 
@@ -4551,7 +4638,7 @@ msgstr ""
 msgid "This is a thumbnail of an image attachment."
 msgstr ""
 
-#: lib/Indices.php:415 lib/Indices.php:710
+#: lib/Indices.php:428 lib/Indices.php:739
 msgid "This mailbox is read-only."
 msgstr ""
 
@@ -4560,17 +4647,17 @@ msgstr ""
 msgid "This message contains a Macintosh file (named \"%s\")."
 msgstr ""
 
-#: lib/Mime/Viewer/Html.php:252
+#: lib/Mime/Viewer/Html.php:258
 msgid ""
 "This message contains corrupt styling data so the message contents may not "
 "appear correctly below."
 msgstr ""
 
-#: lib/Mime/Viewer/Html.php:264
+#: lib/Mime/Viewer/Html.php:270
 msgid "This message contains images that cannot be loaded."
 msgstr ""
 
-#: lib/Mime/Viewer/Html.php:183
+#: lib/Mime/Viewer/Html.php:184
 msgid "This message may not be from whom it claims to be."
 msgstr ""
 
@@ -4596,7 +4683,7 @@ msgid ""
 "This part contains an attachment that can not be displayed within this part:"
 msgstr ""
 
-#: lib/Mime/Viewer/Alternative.php:179
+#: lib/Mime/Viewer/Alternative.php:188
 msgid "This part contains no message contents."
 msgstr ""
 
@@ -4605,7 +4692,7 @@ msgstr ""
 msgid "This video file is reported to be %s in length."
 msgstr ""
 
-#: config/prefs.php:1462 lib/Dynamic/Mailbox.php:262
+#: config/prefs.php:1475 lib/Dynamic/Mailbox.php:261
 msgid "Thread"
 msgstr ""
 
@@ -4617,7 +4704,7 @@ msgstr ""
 msgid "Thread List"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:270
+#: lib/Dynamic/Mailbox.php:269
 msgid "Thread Sort"
 msgstr ""
 
@@ -4625,9 +4712,9 @@ msgstr ""
 msgid "Thread View"
 msgstr ""
 
-#: lib/Basic/Contacts.php:100 lib/Basic/Search.php:64 lib/Compose.php:2775
-#: lib/Contents/View.php:223 lib/Dynamic/Mailbox.php:186
-#: lib/Dynamic/Mailbox.php:260 lib/Smartmobile.php:188
+#: lib/Basic/Contacts.php:100 lib/Basic/Search.php:64 lib/Compose.php:2786
+#: lib/Contents/View.php:229 lib/Dynamic/Mailbox.php:185
+#: lib/Dynamic/Mailbox.php:259 lib/Smartmobile.php:190
 #: templates/contacts/contacts.html.php:34
 #: templates/dynamic/compose.html.php:114
 #: templates/dynamic/mailbox.html.php:146 templates/dynamic/message.html.php:88
@@ -4635,35 +4722,35 @@ msgstr ""
 msgid "To"
 msgstr ""
 
-#: config/prefs.php:1459
+#: config/prefs.php:1472
 msgid "To Address"
 msgstr ""
 
-#: lib/Dynamic/Base.php:161
+#: lib/Dynamic/Base.php:163
 msgid "To All"
 msgstr ""
 
-#: lib/Dynamic/Base.php:162
+#: lib/Dynamic/Base.php:164
 msgid "To List"
 msgstr ""
 
-#: lib/Dynamic/Base.php:160
+#: lib/Dynamic/Base.php:162
 msgid "To Sender"
 msgstr ""
 
 #: lib/Basic/Thread.php:119 lib/Basic/Thread.php:121 lib/Mailbox/Ui.php:75
 #: templates/dynamic/redirect.html.php:14
 #: templates/smartmobile/compose.html.php:7
-#: templates/smartmobile/compose.html.php:29
+#: templates/smartmobile/compose.html.php:31
 msgid "To:"
 msgstr ""
 
-#: lib/Message/Date.php:135
+#: lib/Message/Date.php:134
 #, php-format
 msgid "Today, %s %s"
 msgstr ""
 
-#: config/prefs.php:548
+#: config/prefs.php:555
 msgid "Top"
 msgstr ""
 
@@ -4671,7 +4758,7 @@ msgstr ""
 msgid "Total"
 msgstr ""
 
-#: lib/Mailbox.php:1731 lib/Mailbox.php:1813
+#: lib/Mailbox.php:1750 lib/Mailbox.php:1832
 msgid "Trash"
 msgstr ""
 
@@ -4688,6 +4775,10 @@ msgstr ""
 msgid "Type: %s"
 msgstr ""
 
+#: lib/Ajax/Imple/ItipRequest.php:212
+msgid "Unable to determine attendee address."
+msgstr ""
+
 #: lib/Quota/Hook.php:47 lib/Quota/Imap.php:48
 msgid "Unable to retrieve quota"
 msgstr ""
@@ -4696,11 +4787,11 @@ msgstr ""
 msgid "Unable to view message in preview pane."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:331 lib/Dynamic/Mailbox.php:439
+#: lib/Dynamic/Mailbox.php:330 lib/Dynamic/Mailbox.php:438
 msgid "Undelete"
 msgstr ""
 
-#: lib/Basic/Thread.php:295 lib/Contents/Message.php:298 lib/Mailbox/Ui.php:81
+#: lib/Basic/Thread.php:295 lib/Contents/Message.php:299 lib/Mailbox/Ui.php:81
 msgid "Undisclosed Recipients"
 msgstr ""
 
@@ -4709,64 +4800,64 @@ msgstr ""
 msgid "Unhandled component of type: %s"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:881 lib/Pgp.php:847 lib/Pgp.php:848 lib/Pgp.php:849
+#: lib/Mime/Viewer/Itip.php:946 lib/Pgp.php:886 lib/Pgp.php:887 lib/Pgp.php:888
 msgid "Unknown"
 msgstr ""
 
-#: lib/Message/Date.php:142
+#: lib/Message/Date.php:141
 msgid "Unknown Date"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:434 lib/Mime/Viewer/Itip.php:619
+#: lib/Mime/Viewer/Itip.php:502 lib/Mime/Viewer/Itip.php:687
 msgid "Unknown Meeting"
 msgstr ""
 
-#: lib/Prefs/AttribText.php:65 lib/Prefs/AttribText.php:81
+#: lib/Prefs/AttribText.php:64 lib/Prefs/AttribText.php:80
 msgid "Unknown Sender"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:787
+#: lib/Mime/Viewer/Itip.php:852
 msgid "Unknown Task"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:66
-#: lib/Prefs/Special/SmimePrivateKey.php:115
-#: lib/Prefs/Special/SmimePrivateKey.php:117
+#: lib/Prefs/Special/PgpPrivateKey.php:64
+#: lib/Prefs/Special/SmimePrivateKey.php:116
+#: lib/Prefs/Special/SmimePrivateKey.php:118
 msgid "Unload Passphrase"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:322 lib/Dynamic/Mailbox.php:432
+#: lib/Dynamic/Mailbox.php:321 lib/Dynamic/Mailbox.php:431
 msgid "Unmark as"
 msgstr ""
 
-#: lib/Block/Summary.php:108 lib/Dynamic/Mailbox.php:245
+#: lib/Block/Summary.php:108 lib/Dynamic/Mailbox.php:244
 #: lib/Flag/System/Unseen.php:44
 msgid "Unseen"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:367
+#: lib/Dynamic/Mailbox.php:366
 msgid "Unsubscribe"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:568
+#: lib/Dynamic/Mailbox.php:567
 #, php-format
 msgid "Unsubscribe to %s?"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:569
+#: lib/Dynamic/Mailbox.php:568
 #, php-format
 msgid "Unsubscribe to all subfolders of %s?"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:338 lib/Mime/Viewer/Itip.php:398
+#: lib/Mime/Viewer/Itip.php:366 lib/Mime/Viewer/Itip.php:466
 msgid "Update in my calendar"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:380 lib/Mime/Viewer/Itip.php:772
+#: lib/Mime/Viewer/Itip.php:405 lib/Mime/Viewer/Itip.php:837
 msgid "Update respondent status"
 msgstr ""
 
-#: lib/Mime/Viewer/Itip.php:353
+#: lib/Mime/Viewer/Itip.php:381
 msgid "Update this event on my calendar"
 msgstr ""
 
@@ -4790,11 +4881,11 @@ msgstr ""
 msgid "Use Default Value"
 msgstr ""
 
-#: config/prefs.php:1524
+#: config/prefs.php:1537
 msgid "Use IMAP mailbox subscriptions?"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:313 templates/dynamic/mailbox.html.php:48
+#: lib/Dynamic/Mailbox.php:312 templates/dynamic/mailbox.html.php:48
 #: templates/dynamic/mailbox.html.php:120
 msgid "Use Template"
 msgstr ""
@@ -4811,7 +4902,7 @@ msgstr ""
 msgid "Use secure connection?"
 msgstr ""
 
-#: config/prefs.php:686
+#: config/prefs.php:693
 msgid "Use the charset of the original message when replying?"
 msgstr ""
 
@@ -4819,7 +4910,7 @@ msgstr ""
 msgid "User"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:551
+#: lib/Dynamic/Mailbox.php:550
 msgid "User Options"
 msgstr ""
 
@@ -4827,7 +4918,7 @@ msgstr ""
 msgid "User can see the mailbox"
 msgstr ""
 
-#: lib/Application.php:420
+#: lib/Application.php:427
 msgid "User is not authenticated."
 msgstr ""
 
@@ -4835,20 +4926,20 @@ msgstr ""
 msgid "Username"
 msgstr ""
 
-#: lib/Dynamic/Base.php:196
+#: lib/Dynamic/Base.php:198
 msgid "Verifying..."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:428
+#: lib/Dynamic/Mailbox.php:427
 msgid "Vertical Layout"
 msgstr ""
 
-#: lib/Contents.php:1307
+#: lib/Contents.php:1314
 msgid "Video"
 msgstr ""
 
-#: lib/Prefs/Special/SmimePrivateKey.php:99
-#: lib/Prefs/Special/SmimePrivateKey.php:148
+#: lib/Prefs/Special/SmimePrivateKey.php:100
+#: lib/Prefs/Special/SmimePrivateKey.php:149
 #: templates/prefs/pgpprivatekey.html.php:21
 #: templates/prefs/pgpprivatekey.html.php:35
 #: templates/prefs/pgppublickey.html.php:20
@@ -4856,13 +4947,13 @@ msgstr ""
 msgid "View"
 msgstr ""
 
-#: lib/Contents.php:814 lib/Contents.php:1003
+#: lib/Contents.php:816 lib/Contents.php:1005
 #, php-format
 msgid "View %s"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPublicKey.php:77
-#: lib/Prefs/Special/SmimePublicKey.php:75
+#: lib/Prefs/Special/PgpPublicKey.php:75
+#: lib/Prefs/Special/SmimePublicKey.php:73
 #, php-format
 msgid "View %s Public Key"
 msgstr ""
@@ -4879,7 +4970,7 @@ msgstr ""
 msgid "View HTML data in new window."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:315
+#: lib/Dynamic/Mailbox.php:314
 msgid "View Message"
 msgstr ""
 
@@ -4887,32 +4978,32 @@ msgstr ""
 msgid "View PDF File"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:77
+#: lib/Prefs/Special/PgpPrivateKey.php:75
 msgid "View Personal Private Key"
 msgstr ""
 
-#: lib/Prefs/Special/SmimePrivateKey.php:96
+#: lib/Prefs/Special/SmimePrivateKey.php:97
 msgid "View Personal Public Certificate"
 msgstr ""
 
-#: lib/Prefs/Special/PgpPrivateKey.php:55
+#: lib/Prefs/Special/PgpPrivateKey.php:53
 msgid "View Personal Public Key"
 msgstr ""
 
-#: lib/Prefs/Special/SmimePrivateKey.php:145
+#: lib/Prefs/Special/SmimePrivateKey.php:146
 msgid "View Secondary Personal Private Key"
 msgstr ""
 
-#: lib/Prefs/Special/SmimePrivateKey.php:95
+#: lib/Prefs/Special/SmimePrivateKey.php:96
 msgid "View Secondary Personal Public Certificate"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:334 lib/Dynamic/Mailbox.php:469
+#: lib/Dynamic/Mailbox.php:333 lib/Dynamic/Mailbox.php:468
 #: templates/dynamic/message.html.php:41 templates/dynamic/message.html.php:43
 msgid "View Source"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:471
+#: lib/Dynamic/Mailbox.php:470
 msgid "View Thread"
 msgstr ""
 
@@ -4928,8 +5019,9 @@ msgstr ""
 msgid "View details of the returned message."
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:497 lib/Ajax/Imple/ItipRequest.php:498
-#: lib/Ajax/Imple/ItipRequest.php:520 lib/Ajax/Imple/ItipRequest.php:521
+#: lib/Ajax/Imple/ItipRequest.php:643 lib/Ajax/Imple/ItipRequest.php:644
+#: lib/Ajax/Imple/ItipRequest.php:666 lib/Ajax/Imple/ItipRequest.php:667
+#: lib/Mime/Viewer/Itip.php:351 lib/Mime/Viewer/Itip.php:352
 msgid "View event"
 msgstr ""
 
@@ -4941,7 +5033,7 @@ msgstr ""
 msgid "View or mailbox to display after login:"
 msgstr ""
 
-#: lib/Ajax/Imple/ItipRequest.php:255 lib/Ajax/Imple/ItipRequest.php:256
+#: lib/Ajax/Imple/ItipRequest.php:340 lib/Ajax/Imple/ItipRequest.php:341
 msgid "View task"
 msgstr ""
 
@@ -4949,7 +5041,7 @@ msgstr ""
 msgid "View the text of the original sent message."
 msgstr ""
 
-#: config/prefs.php:970
+#: config/prefs.php:978
 msgid "Viewing"
 msgstr ""
 
@@ -4962,7 +5054,7 @@ msgstr ""
 msgid "Virtual Folder \"%s\" created succesfully."
 msgstr ""
 
-#: lib/Prefs/Special/Searches.php:132
+#: lib/Prefs/Special/Searches.php:130
 #, php-format
 msgid "Virtual Folder \"%s\" deleted."
 msgstr ""
@@ -4972,12 +5064,12 @@ msgstr ""
 msgid "Virtual Folder \"%s\" edited successfully."
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:559
+#: lib/Dynamic/Mailbox.php:558
 #, php-format
 msgid "Virtual Folder: %s"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:277 lib/Mailbox.php:1657
+#: lib/Dynamic/Mailbox.php:276 lib/Mailbox.php:1676
 #: templates/flist/flist.html.php:27
 msgid "Virtual Folders"
 msgstr ""
@@ -4994,43 +5086,43 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: config/prefs.php:596
+#: config/prefs.php:603
 msgid ""
 "What language(s) do you prefer replies to your messages to be in? (Hold down "
 "the CTRL key when clicking to add multiple languages)"
 msgstr ""
 
-#: config/prefs.php:1272
+#: config/prefs.php:1285
 msgid "What to do with messages after they have been reported as innocent?"
 msgstr ""
 
-#: config/prefs.php:1251
+#: config/prefs.php:1264
 msgid "What to do with messages after they have been reported as spam?"
 msgstr ""
 
-#: config/prefs.php:753
+#: config/prefs.php:760
 msgid ""
 "When forwarding a message in the body text, should the same format as the "
 "original message be used?"
 msgstr ""
 
-#: config/prefs.php:1446
+#: config/prefs.php:1459
 msgid "When opening a mailbox for the first time, where do you want to start?"
 msgstr ""
 
-#: config/prefs.php:682
+#: config/prefs.php:689
 msgid "When replying, use the same format as the original message?"
 msgstr ""
 
-#: config/prefs.php:551
+#: config/prefs.php:558
 msgid "Where should the cursor be located in the compose text area by default?"
 msgstr ""
 
-#: config/prefs.php:1079
+#: config/prefs.php:1092
 msgid "Which message parts do you want to display in the summary?"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:328 lib/Dynamic/Mailbox.php:435
+#: lib/Dynamic/Mailbox.php:327 lib/Dynamic/Mailbox.php:434
 msgid "Whitelist"
 msgstr ""
 
@@ -5042,16 +5134,16 @@ msgstr ""
 msgid "Years"
 msgstr ""
 
-#: config/prefs.php:584 config/prefs.php:829 config/prefs.php:1535
+#: config/prefs.php:591 config/prefs.php:836 config/prefs.php:1548
 msgid "Yes"
 msgstr ""
 
-#: lib/Message/Date.php:158
+#: lib/Message/Date.php:157
 #, php-format
 msgid "Yesterday, %s"
 msgstr ""
 
-#: lib/Message/Date.php:118
+#: lib/Message/Date.php:117
 #, php-format
 msgid "Yesterday, %s %s"
 msgstr ""
@@ -5069,7 +5161,7 @@ msgstr ""
 msgid "You are not allowed to create more than %d mailboxes."
 msgstr ""
 
-#: lib/Compose.php:1447
+#: lib/Compose.php:1448
 #, php-format
 msgid ""
 "You are not allowed to send messages to more than %d recipient within %d "
@@ -5080,14 +5172,14 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/Compose.php:1462
+#: lib/Compose.php:1463
 #, php-format
 msgid "You are not allowed to send messages to more than %d recipient."
 msgid_plural "You are not allowed to send messages to more than %d recipients."
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/Indices.php:459
+#: lib/Indices.php:474
 msgid ""
 "You are over your quota, so your messages will be permanently deleted "
 "instead of moved to the Trash mailbox."
@@ -5102,7 +5194,7 @@ msgstr ""
 msgid "You cannot unsubscribe from \"%s\"."
 msgstr ""
 
-#: lib/Prefs/Special/Acl.php:53
+#: lib/Prefs/Special/Acl.php:51
 msgid "You do not have permission to change access to this mailbox."
 msgstr ""
 
@@ -5122,7 +5214,7 @@ msgid_plural "You have %d new mail messages in %s."
 msgstr[0] ""
 msgstr[1] ""
 
-#: config/prefs.php:1145 config/prefs.php:1170
+#: config/prefs.php:1158 config/prefs.php:1183
 msgid ""
 "You have activated move to Trash but no Trash mailbox is defined. You will "
 "be unable to delete messages until you set a Trash mailbox in the "
@@ -5172,7 +5264,7 @@ msgstr ""
 msgid "You must select an address first."
 msgstr ""
 
-#: lib/Dynamic/Base.php:193
+#: lib/Dynamic/Base.php:195
 msgid ""
 "You need to either use the keyboard (Ctrl/Cmd + C) or right click on the "
 "selected address to access the Copy command."
@@ -5213,7 +5305,7 @@ msgstr ""
 msgid "You were successfully subscribed to \"%s\" and all subfolders."
 msgstr ""
 
-#: lib/Mailbox.php:939
+#: lib/Mailbox.php:939 lib/Mailbox.php:965
 #, php-format
 msgid "You were successfully subscribed to \"%s\"."
 msgstr ""
@@ -5223,7 +5315,7 @@ msgstr ""
 msgid "You were successfully unsubscribed from \"%s\" and all subfolders."
 msgstr ""
 
-#: lib/Mailbox.php:940
+#: lib/Mailbox.php:940 lib/Mailbox.php:966
 #, php-format
 msgid "You were successfully unsubscribed from \"%s\"."
 msgstr ""
@@ -5256,7 +5348,7 @@ msgstr ""
 msgid "Your Public Key"
 msgstr ""
 
-#: config/prefs.php:29
+#: config/prefs.php:33
 msgid "Your Reply-to: address: <em>(optional)</em>"
 msgstr ""
 
@@ -5286,7 +5378,7 @@ msgstr ""
 msgid "Your Secondary S/MIME Personal Certificate has expired on %s at %s."
 msgstr ""
 
-#: config/prefs.php:36
+#: config/prefs.php:40
 msgid ""
 "Your alias addresses: <em>(optional, enter each address on a new line)</em>"
 msgstr ""
@@ -5306,13 +5398,19 @@ msgstr ""
 msgid "Your browser does not support inline display of this image type."
 msgstr ""
 
-#: lib/Dynamic/Base.php:193
+#: lib/Dynamic/Base.php:195
 msgid ""
 "Your browser security settings don't permit direct access to the clipboard."
 msgstr ""
 
 #: templates/prefs/encrypt.html.php:3
 msgid "Your default encryption method for sending messages:"
+msgstr ""
+
+#: src/IdentityDriverPrefs.php:222
+msgid ""
+"Your identity does not have a valid email address. Please set one in your "
+"personal preferences before sending mail."
 msgstr ""
 
 #: templates/dynamic/compose.html.php:185
@@ -5326,7 +5424,13 @@ msgstr ""
 msgid "Your linked attachment has been downloaded by at least one user."
 msgstr ""
 
-#: lib/Compose.php:767
+#: src/IdentityDriverPrefs.php:231
+#, php-format
+msgid ""
+"Your login name \"%s\" has been set as the email address for your identity."
+msgstr ""
+
+#: lib/Compose.php:768
 #, php-format
 msgid "Your message body has exceeded the limit by body size by %d characters."
 msgstr ""
@@ -5335,33 +5439,57 @@ msgstr ""
 msgid "Your message was successfully delivered."
 msgstr ""
 
+#: lib/Ajax/Imple/ItipRequest.php:573
+msgid "Your proposed new time was declined by the organizer."
+msgstr ""
+
 #: templates/prefs/signaturehtml.html.php:2
 msgid ""
 "Your signature to use when composing with the HTML editor (if empty, the "
 "text signature will be used)"
 msgstr ""
 
-#: config/prefs.php:56
+#: config/prefs.php:60
 msgid "Your signature:"
 msgstr ""
 
-#: lib/Compose.php:2741 lib/Contents/Message.php:444 lib/Mailbox/Ui.php:120
-#: lib/Prefs/AttribText.php:105
+#: lib/Pgp.php:198
+msgid "Your stored PGP private key appears corrupt and could not be loaded."
+msgstr ""
+
+#: lib/Pgp.php:178
+msgid "Your stored PGP public key appears corrupt and could not be loaded."
+msgstr ""
+
+#: lib/Smime.php:246 lib/Smime.php:257
+msgid "Your stored S/MIME certificate appears corrupt and could not be loaded."
+msgstr ""
+
+#: lib/Smime.php:209 lib/Smime.php:220
+msgid "Your stored S/MIME private key appears corrupt and could not be loaded."
+msgstr ""
+
+#: lib/Smime.php:172 lib/Smime.php:183
+msgid "Your stored S/MIME public key appears corrupt and could not be loaded."
+msgstr ""
+
+#: lib/Compose.php:2752 lib/Contents/Message.php:445 lib/Mailbox/Ui.php:120
+#: lib/Prefs/AttribText.php:115
 msgid "[No Subject]"
 msgstr ""
 
-#: lib/Indices.php:584
+#: lib/Indices.php:613
 #, php-format
 msgid "[Part stripped: Original part type: %s, name: %s]"
 msgstr ""
 
-#: lib/Compose.php:3190
+#: lib/Compose.php:3225
 msgid "[Truncated Text]"
 msgstr ""
 
 #: lib/Basic/Search.php:500
 #: lib/Notification/Handler/Decorator/NewmailNotify.php:98
-#: lib/Search/Filter.php:44 lib/Search/Query.php:275
+#: lib/Search/Filter.php:44 lib/Search/Query.php:291
 msgid "and"
 msgstr ""
 
@@ -5372,15 +5500,15 @@ msgid_plural "and %d more mailboxes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/Compose.php:3364
+#: lib/Compose.php:3399
 msgid "attachment"
 msgstr ""
 
-#: lib/Contents/View.php:54
+#: lib/Contents/View.php:59
 msgid "attachments.zip"
 msgstr ""
 
-#: lib/Dynamic/Mailbox.php:528
+#: lib/Dynamic/Mailbox.php:527
 msgid "base level of the folder tree"
 msgstr ""
 
@@ -5402,7 +5530,7 @@ msgstr ""
 msgid "key"
 msgstr ""
 
-#: lib/Compose.php:3068
+#: lib/Compose.php:3103
 #, php-format
 msgid "links will expire on %s"
 msgstr ""
@@ -5436,7 +5564,7 @@ msgstr ""
 msgid "months"
 msgstr ""
 
-#: lib/Compose.php:1258
+#: lib/Compose.php:1259
 msgid "name"
 msgstr ""
 
@@ -5447,7 +5575,7 @@ msgstr ""
 msgid "not"
 msgstr ""
 
-#: lib/Contents/View.php:70
+#: lib/Contents/View.php:75
 #, php-format
 msgid "part %s"
 msgstr ""


### PR DESCRIPTION
## What & why

`ngettext()` calls had both arguments wrapped in an extra `_()`:

```php
ngettext(_('%d minute'), _('%d minutes'), $minutes)
```

This causes `xgettext` to extract `%d minute` and `%d minutes` as two independent plain msgids instead of a plural pair, which broke `hordectl translation compendium` when merging against other modules (e.g. kronolith) that define the same strings with a proper plural form:

```
msgcat: msgid '%d minute' est utilisé sans et avec le pluriel.
```

Removing the inner `_()` calls lets `ngettext()` be extracted correctly as a plural pair. No behavior change — `ngettext()` already receives the raw strings it needs at runtime.

The `.pot` file has been regenerated to reflect the corrected extraction.