### PR TITLE
Fix incorrect preview pane height on session start in horiz mode

### DIFF
--- a/js/viewport.js
+++ b/js/viewport.js
@@ -511,8 +511,9 @@ var ViewPort = Class.create({
             });
             this.opts.content.setStyle({ width: 'auto' });
             sp.currbar.show();
+            this.opts.pane_data.show();
             var _ph = Math.max(document.viewport.getHeight() - this.opts.pane_data.viewportOffset()[1], 0);
-            this.opts.pane_data.show().setStyle({
+            this.opts.pane_data.setStyle({
                 height: _ph + 'px'
             });
             document.documentElement.style.setProperty('--imp-pane-mode', 'horiz');


### PR DESCRIPTION
ViewPort#_onResize() (horiz case) read pane_data.viewportOffset()
before calling pane_data.show(). Since #previewPane starts as
display:none in the mailbox template, viewportOffset() returns 0
for a hidden element, so the computed pane height
(document.viewport.getHeight() - offset) equals the full window
height instead of window height minus the space already used above
the pane (toolbar, message list, etc).

This wrong height is set as an inline style and is only ever
recalculated on an explicit window resize or pane-mode toggle, so
it silently affects every message previewed for the rest of the
session until one of those events fires by chance (e.g. opening
browser DevTools, which itself triggers a resize).

Fix: show() the pane before measuring its offset.

To reproduce: load the dynamic view fresh (no prior resize or
pane-mode toggle this session), horiz layout, and preview any
message. The preview pane will be sized to the full window height,
pushing content below the visible area with no way to scroll to it.

While investigating, a second, unrelated possible issue was found in
the lazy image-loading code (js/imp.js, IMP_JS.iframeImgLazyLoadRun):
its visible-range calculation mixes coordinates from the IFRAME's
own document with mb.scrollTop from the parent document, which can
under-compute the range on very long messages. This was not
triggered after applying the fix in this commit, so it has not
been tested or fixed here.